### PR TITLE
Fix Arkham Origins Savefile Prefix; fix Crimes in Progress parsing

### DIFF
--- a/ArkhamDisplay/OriginsSave.cs
+++ b/ArkhamDisplay/OriginsSave.cs
@@ -5,13 +5,18 @@ namespace ArkhamDisplay{
 		public OriginsSave(string filePath, int id) : base(filePath, id){}
 
 		public override bool HasKey(Entry entry){
-			if(entry.type.Equals("Data Handler")){
+			if("Data Handler".Equals(entry.type)){
 				return !HasKey(entry.id) && !HasKey(entry.alternateID);
-			}else if (entry.metadata.Equals("DarkKnightFinish")){
+			}else if ("DarkKnightFinish".Equals(entry.metadata)){
 				return HasKeyCustomRegex(@"\b" + entry.id + @"............" + Convert.ToChar(Convert.ToByte("0x1", 16)));
 			}
 
 			return base.HasKey(entry);
+		}
+
+		protected override string GetFile()
+		{
+			return System.IO.Path.Combine(m_filePath, "SpSave_v2_" + m_id.ToString() + ".sgd");
 		}
 	}
 }


### PR DESCRIPTION
The Arkham Origins savefile wasn't loading because its prefix is "SPSave_v2_" as opposed to "Save". This change fixes that.

Also, the crimes in progress weren't parsing because the "metadata" field is null, and doing .Equals on null. This change makes that check resilient to nulls.