### PR TITLE
Remove Diagnostics from NG+

### DIFF
--- a/ArkhamDisplay/Routes/Arkham Knight 100% Route - NG+ Route 120.tsv
+++ b/ArkhamDisplay/Routes/Arkham Knight 100% Route - NG+ Route 120.tsv
@@ -3,7 +3,6 @@ Visit Gordon	Main Story	Ch1b_CityZ_Met_Gordon
 Pyg (Bleake, South Failure; Arm Chest Knee)	Pyg	SS_Pyg_Victim1Done	https://static.gosunoob.com/img/1/2015/07/The_Perfect_Crime_Batman_Arkham_Knight_1-1024x576.jpg	https://youtu.be/0SnppYd7wSg?t=331
 Even the Odds	Main Story	Ch1b_CityZ_Suspicious_Vehicle_Driver_Interrogated 		
 Ivy	Main Story	Ch1bc_CityZ_Light_Tank_Reinforcements_Destroyed 		
-Diagnostics	Main Story	Ch1_CityZ_Battle_Mode_Tutorial_Complete 		
 Firemen (Bleake Island, Dixon Docks)	Firemen	SS_FireCrew_0_Rescued 	https://static.gosunoob.com/img/1/2015/07/Bleake_Island_Missing_Firefighter_Batman_Arkham_Knight-1024x576.jpg	
 PanessaTankFight	Main Story	Ch1b_CityZ_All_Light_Tanks_Destroyed 		
 Pyg (Bleake, MerchantBridge; Ear Abdomen Hip)	Pyg	SS_Pyg_Victim2Done	https://static.gosunoob.com/img/1/2015/07/Batman_Arkham_Knight_The_Perfect_Crime_Bleake_Island_1-1024x576.jpg	

--- a/ArkhamDisplay/Routes/Arkham Knight 100% Route - NG+ Route.tsv
+++ b/ArkhamDisplay/Routes/Arkham Knight 100% Route - NG+ Route.tsv
@@ -3,7 +3,6 @@ Visit Gordon	Main Story	Ch1b_CityZ_Met_Gordon
 Pyg (Bleake, South Failure; Arm Chest Knee)	Pyg	SS_Pyg_Victim1Done	https://static.gosunoob.com/img/1/2015/07/The_Perfect_Crime_Batman_Arkham_Knight_1-1024x576.jpg	https://youtu.be/0SnppYd7wSg?t=331
 Even the Odds	Main Story	Ch1b_CityZ_Suspicious_Vehicle_Driver_Interrogated 		
 Ivy	Main Story	Ch1bc_CityZ_Light_Tank_Reinforcements_Destroyed 		
-Diagnostics	Main Story	Ch1_CityZ_Battle_Mode_Tutorial_Complete 		
 Firemen (Bleake Island, Dixon Docks)	Firemen	SS_FireCrew_0_Rescued 	https://static.gosunoob.com/img/1/2015/07/Bleake_Island_Missing_Firefighter_Batman_Arkham_Knight-1024x576.jpg	
 PanessaTankFight	Main Story	Ch1b_CityZ_All_Light_Tanks_Destroyed 		
 Pyg (Bleake, MerchantBridge; Ear Abdomen Hip)	Pyg	SS_Pyg_Victim2Done	https://static.gosunoob.com/img/1/2015/07/Batman_Arkham_Knight_The_Perfect_Crime_Bleake_Island_1-1024x576.jpg	


### PR DESCRIPTION
You don't need to do the initial diagnostics in NG+, so they shouldn't be part of the NG+ route. This change removes it from the NG+ 100% and 120% files.