### PR TITLE
Add missing trophy

### DIFF
--- a/ArkhamDisplay/Routes/Catwoman.tsv
+++ b/ArkhamDisplay/Routes/Catwoman.tsv
@@ -369,6 +369,7 @@ Cat Trophy (Museum, floor grate in Torture Chamber)	Riddler Trophies (Catwoman)	
 Cat Trophy (Museum, Torture Chamber ceiling)	Riddler Trophies (Catwoman)	PickedUp_Museum_CWPickup_3		
 Cat Trophy (Museum, on Freeze showcase)	Riddler Trophies (Catwoman)	PickedUp_Museum_CWPickup_4		
 Cat Trophy (Museum, predator right side)	Riddler Trophies (Catwoman)	PickedUp_Museum_CWPickup_5		
+Trophy (Bowery, Rec gun sphere)	Riddler Trophies	PickedUp_OWE_Pickup_28		
 Trophy (Park Row, 2 mine disrupts [with zsasz call])	Riddler Trophies	PickedUp_OWA_Pickup_29		
 Trophy (Park Row, 3 questionmark gel by hoboshelter)	Riddler Trophies	PickedUp_OWA_Pickup_9		
 Deadshot Victim 2	Deadshot	SS_DeadShot_Hobo2_RustScanned		


### PR DESCRIPTION
The Rec Gun Sphere trophy got removed by accident. Adding it back.