### PR TITLE
Update Knight and Origins routes

### DIFF
--- a/ArkhamDisplay/Routes/Knight-FirstEnding.tsv
+++ b/ArkhamDisplay/Routes/Knight-FirstEnding.tsv
@@ -1,65 +1,61 @@
-Name	Type	SaveFileId	Alternate ID	Metadata	Image	Video
-Visit Gordon	Main Story	Ch1b_CityZ_Met_Gordon 				
-Pyg (Bleake, South Failure; Arm Chest Knee)	Pyg	SS_Pyg_Victim1Done			https://static.gosunoob.com/img/1/2015/07/The_Perfect_Crime_Batman_Arkham_Knight_1-1024x576.jpg	
-Critical Strikes Upgrade	Upgrades	Unlocked_CriticalStrikes 				
-Even the Odds	Main Story	Ch1b_CityZ_Suspicious_Vehicle_Driver_Interrogated 				
-Ivy	Main Story	Ch1bc_CityZ_Light_Tank_Reinforcements_Destroyed 				
-Diagnostics	Main Story	Ch1_CityZ_Battle_Mode_Tutorial_Complete 				
-PanessaTankFight	Main Story	Ch1b_CityZ_All_Light_Tanks_Destroyed 				
-Pyg (Bleake, MerchantBridge; Ear Abdomen Hip)	Pyg	SS_Pyg_Victim2Done			https://static.gosunoob.com/img/1/2015/07/Batman_Arkham_Knight_The_Perfect_Crime_Bleake_Island_1-1024x576.jpg	
-IvyToGCPD	Main Story	Ch1bc_CityZ_Gordon_Ivy_Convo_done 				
-Clock Tower (Main Story)	Main Story	Ch1c2_Clocktower_C1_Meet_Oracle_Cine_Complete 				
-Panessa Antenna (Main Story)	Main Story	Ch2_CityZ_10_Batman_On_Movie_Studios				
-Power Antenna (Main Story)	Main Story	Ch2_CityZ_10_Powering_Up_Antenna_01_Complete 				
-2nd Antenna (Main Story)	Main Story	Ch2_CityZ_18_Second_Antenna_Activated 				
-Ace Chemicals (Main Story)	Main Story	ACE_Ch3_BridgeDestroyed 				
-Escort Gordon to Clock Tower (Main Story)	Main Story	Ch3a_CityZ_Protect_Gordon_Chase_Started     				
-Track Oracle (Main Story)	Main Story	Ch3b_TireTrailActive 				
-Riddler Orphanage 1	Riddler Mission	Orphan_A1_Intro_Robots_Done 				
-Pyg (Miagani, NearFoundersIsland; Torso Eye Arm)	Pyg	SS_Pyg_Victim4Done 				
-Pyg (Miagani, NearMercyBridge; Chest Arm Toe)	Pyg	SS_Pyg_Victim3Done 				
-Multiground Takedown Upgrade	Upgrades	Unlocked_MultiGroundTakedown				
-Investigate Oracle Crash	Main Story	Ch3_CityX_08_APC_Forensics_Complete				
-Firefly (Miagani Island, Bristol Fire Station near Fairgrounds)	Firefly	SS_Firefly_CityX_Complete 			https://static.gosunoob.com/img/1/2015/07/miagani-island-bristol-fire-station-1024x576.jpg	
-Azrael 1 (Near Parking, use map)	Azrael	SS_Azrael_Fight1_Complete 				
-First Cache Destroyed (Near Parking)	Main Story	Penguin_Cache_Completed 				
-Afterburner Recharge 1	Upgrades	Unlocked_BmblBoostCharge1				
-Afterburner Recharge 2	Upgrades	Unlocked_BmblBoostCharge2				
-Firefly (Bleake Island, Fire Station by Water Near GCPD)	Firefly	SS_Firefly_CityZ_Complete 			https://static.gosunoob.com/img/1/2015/07/bleake-island-cauldron-fire-station-1024x576.jpg	
-Stagg Scarecrow	Main Story	CH4_StaggB3_Scarecrow_Defeated 				
-GCPD/Ivy/Cobras	Main Story	Ch5b_CityZ_17_Heavy_Tank_Scanning_Complete 				
-Cobra Lure Upgrade	Upgrades	Unlocked_BmblHeavyCannonLure				
-Wayne Tower Tank Fight	Main Story	Ch5b_WayneTower_Tanks_Complete 				
-Use Sonar	Main Story	Ch5b_ProtectIvyPlantSiteX_ObjectiveComplete 				
-Two Face Bank 1 (Bleake)	Two Face	Bank01_Empty 				
-Collect Freeze Blast	Gadget	Equip_FreezeSpray 				
-Drone + Radar 1 (Main Story)	Main Story	Ch5c_CityY_Radar_1_Destroyed 				
-Two Face Bank 2 (Founders)	Two Face	Bank02_Empty 				
-Azrael 2 (near firefly, use map)	Azrael	SS_Azrael_Fight2_Complete				
-Radar 2 (Main Story)	Main Story	Ch5c_CityY_Radar_2_Destroyed 				
-Long Range Missle Launcher (Main Story)	Main Story	CityY_Missile_Launcher_2_Dead 				
-Pyg (Founders, EastNearWater; leg abdomen skull)	Pyg	SS_Pyg_Victim5Done 			https://static.gosunoob.com/img/1/2015/07/Batman_Arkham_Knight_Unidentified_Body_The_Perfect_Crime_1-1024x576.jpg	
-Pyg (Founders, North; Thigh Shoulder Hand)	Pyg	SS_Pyg_Victim6Done			https://static.gosunoob.com/img/1/2015/07/Batman_Arkham_Knight_The_Perfect_Crime_Body_Founders_Island_1-1024x576.jpg	
-Panessa	Main Story	Ch6_CityZ_MovieStudioRoof_VoiceSynth_Obtained 				
-Trigger Hush	Main Story	SS_Hush_WayneTower				
-Azrael 3 (Roundabout, use map)	Azrael	SS_Azrael_Fight3_Complete				
-Cloudless	Main Story	Ch7a_Stagg_A1_Return_To_Batmobile 				
-Manbat blood sample	Manbat	SS_ManBat_SampleTaken 				
-Cannon Reload Speed upgrade	Upgrades	Unlocked_BmblHeavyCannonReload				
-Tank Head Shot Upgrade	Upgrades	Unlocked_BmblHeavyCannonHeadShot 				
-Tank Body Shot Upgrade	Upgrades	Unlocked_BmblHeavyCannonBodyShot 				
-Cloudburst	Main Story	Post_Cloudburst_Restart_Rioting				
-Manbat Lab (use map)	ManBat	SS_ManBat_CreatedCure 				
-Manbat Give Medicine	ManBat	SS_ManBat_Cure_FullDose1 				
-Azrael 4 (LadyGotham)	Azrael	SS_Azrael_Fight4_Complete				
-Reload Speed 2 Upgrade	Upgrades	Unlocked_BmblHeavyCannonReload2 				
-Speak to GCPD Dude	Main Story	Ch8_Track_Gordon_Objective_Added 				
-Scarecrow Done	Main Story	AK_Main_Game_Complete				
-Azrael Done (5 16 28 41) 	Azrael	SS_Azrael_Clocktower_ForensicsStarted				
-Deacon	Deacon	SS_Deacon_COMPLETE 				
-Hush (use map)	Hush	SS_Hush_ShowdownStart 				
-Two Face Bank 3 (Miagani)	Two Face	Bank03_Empty 				
-Pyg Done	Pyg	SS_Pyg_InBatmobile_Dialogue 				
-Manbat Done	ManBat	SS_ManBat_Cure_FullDose2 				
-Firefly (Founders, Near Gothcorp)	Firefly	SS_Firefly_CityY_Complete				
-Knightfall	Main Story					
+Name	Type	SaveFileId	Image	Video
+Visit Gordon	Main Story	Ch1b_CityZ_Met_Gordon 		
+Pyg (Bleake, South Failure; Arm Chest Knee)	Pyg	SS_Pyg_Victim1Done	https://static.gosunoob.com/img/1/2015/07/The_Perfect_Crime_Batman_Arkham_Knight_1-1024x576.jpg	
+Critical Strikes Upgrade	Upgrades	Unlocked_CriticalStrikes 		
+Even the Odds	Main Story	Ch1b_CityZ_Suspicious_Vehicle_Driver_Interrogated 		
+Ivy	Main Story	Ch1bc_CityZ_Light_Tank_Reinforcements_Destroyed 		
+Diagnostics	Main Story	Ch1_CityZ_Battle_Mode_Tutorial_Complete 		
+PanessaTankFight	Main Story	Ch1b_CityZ_All_Light_Tanks_Destroyed 		
+Pyg (Bleake, MerchantBridge; Ear Abdomen Hip)	Pyg	SS_Pyg_Victim2Done	https://static.gosunoob.com/img/1/2015/07/Batman_Arkham_Knight_The_Perfect_Crime_Bleake_Island_1-1024x576.jpg	
+IvyToGCPD	Main Story	Ch1bc_CityZ_Gordon_Ivy_Convo_done 		
+Clock Tower (Main Story)	Main Story	Ch1c2_Clocktower_C1_Meet_Oracle_Cine_Complete 		
+Panessa Antenna (Main Story)	Main Story	Ch2_CityZ_10_Batman_On_Movie_Studios		
+Power Antenna (Main Story)	Main Story	Ch2_CityZ_10_Powering_Up_Antenna_01_Complete 		
+2nd Antenna (Main Story)	Main Story	Ch2_CityZ_18_Second_Antenna_Activated 		
+Ace Chemicals (Main Story)	Main Story	ACE_Ch3_BridgeDestroyed 		
+Escort Gordon to Clock Tower (Main Story)	Main Story	Ch3a_CityZ_Protect_Gordon_Chase_Started     		
+Track Oracle (Main Story)	Main Story	Ch3b_TireTrailActive 		
+Riddler Orphanage 1	Riddler Mission	Orphan_A1_Intro_Robots_Done 		
+Pyg (Miagani, NearFoundersIsland; Torso Eye Arm)	Pyg	SS_Pyg_Victim4Done 		
+Pyg (Miagani, NearMercyBridge; Chest Arm Toe)	Pyg	SS_Pyg_Victim3Done 		
+Multiground Takedown Upgrade	Upgrades	Unlocked_MultiGroundTakedown		
+Investigate Oracle Crash	Main Story	Ch3_CityX_08_APC_Forensics_Complete		
+Firefly (Miagani Island, Bristol Fire Station near Fairgrounds)	Firefly	SS_Firefly_CityX_Complete 	https://static.gosunoob.com/img/1/2015/07/miagani-island-bristol-fire-station-1024x576.jpg	
+Azrael 1 (Near Parking, use map)	Azrael	SS_Azrael_Fight1_Complete 		
+First Cache Destroyed (Near Parking)	Main Story	Penguin_Cache_Completed 		
+Firefly (Bleake Island, Fire Station by Water Near GCPD)	Firefly	SS_Firefly_CityZ_Complete 	https://static.gosunoob.com/img/1/2015/07/bleake-island-cauldron-fire-station-1024x576.jpg	
+Stagg Scarecrow	Main Story	CH4_StaggB3_Scarecrow_Defeated 		
+GCPD/Ivy/Cobras	Main Story	Ch5b_CityZ_17_Heavy_Tank_Scanning_Complete 		
+Cobra Lure Upgrade	Upgrades	Unlocked_BmblHeavyCannonLure		
+Cannon Reload Speed upgrade	Upgrades	Unlocked_BmblHeavyCannonReload		
+Tank Head Shot Upgrade	Upgrades	Unlocked_BmblHeavyCannonHeadShot 		
+Wayne Tower Tank Fight	Main Story	Ch5b_WayneTower_Tanks_Complete 		
+Use Sonar	Main Story	Ch5b_ProtectIvyPlantSiteX_ObjectiveComplete 		
+Collect Freeze Blast	Gadget	Equip_FreezeSpray 		
+Drone + Radar 1 (Main Story)	Main Story	Ch5c_CityY_Radar_1_Destroyed 		
+Azrael 2 (near firefly, use map)	Azrael	SS_Azrael_Fight2_Complete		
+Radar 2 (Main Story)	Main Story	Ch5c_CityY_Radar_2_Destroyed 		
+Long Range Missle Launcher (Main Story)	Main Story	CityY_Missile_Launcher_2_Dead 		
+Pyg (Founders, EastNearWater; leg abdomen skull)	Pyg	SS_Pyg_Victim5Done 	https://static.gosunoob.com/img/1/2015/07/Batman_Arkham_Knight_Unidentified_Body_The_Perfect_Crime_1-1024x576.jpg	
+Pyg (Founders, North; Thigh Shoulder Hand)	Pyg	SS_Pyg_Victim6Done	https://static.gosunoob.com/img/1/2015/07/Batman_Arkham_Knight_The_Perfect_Crime_Body_Founders_Island_1-1024x576.jpg	
+Panessa	Main Story	Ch6_CityZ_MovieStudioRoof_VoiceSynth_Obtained 		
+Trigger Hush	Main Story	SS_Hush_WayneTower		
+Azrael 3 (Roundabout, use map)	Azrael	SS_Azrael_Fight3_Complete		
+Cloudless	Main Story	Ch7a_Stagg_A1_Return_To_Batmobile 		
+Manbat blood sample	Manbat	SS_ManBat_SampleTaken 		
+Tank Body Shot Upgrade	Upgrades	Unlocked_BmblHeavyCannonBodyShot 		
+Cloudburst	Main Story	Post_Cloudburst_Restart_Rioting		
+Manbat Lab (use map)	ManBat	SS_ManBat_CreatedCure 		
+Manbat Give Medicine	ManBat	SS_ManBat_Cure_FullDose1 		
+Azrael 4 (LadyGotham)	Azrael	SS_Azrael_Fight4_Complete		
+Reload Speed 2 Upgrade	Upgrades	Unlocked_BmblHeavyCannonReload2 		
+Speak to GCPD Dude	Main Story	Ch8_Track_Gordon_Objective_Added 		
+Scarecrow Done	Main Story	AK_Main_Game_Complete		
+Azrael Done (5 16 28 41) 	Azrael	SS_Azrael_Clocktower_ForensicsStarted		
+Deacon	Deacon	SS_Deacon_COMPLETE 		
+Hush (use map)	Hush	SS_Hush_ShowdownStart 		
+Two Face Bank 3 (Miagani)	Two Face	Bank03_Empty 		
+Pyg Done	Pyg	SS_Pyg_InBatmobile_Dialogue 		
+Manbat Done	ManBat	SS_ManBat_Cure_FullDose2 		
+Firefly (Founders, Near Gothcorp)	Firefly	SS_Firefly_CityY_Complete		
+Knightfall	Main Story			

--- a/ArkhamDisplay/Routes/Knight.tsv
+++ b/ArkhamDisplay/Routes/Knight.tsv
@@ -18,12 +18,9 @@ Breakable Shield (Bleake Island, PanessaGate)	Breakable Objects	PickedUp_CityZ_M
 Riddler Trophy (Bleake, House Bridge Panessa)	Riddler Trophies	PickedUp_CityZ_Pickup_38 			https://static.gosunoob.com/img/1/2015/06/bak-riddler-trophy-merchant-bridge-1024x576.jpg	
 Pyg (Bleake, MerchantBridge; Ear Abdomen Hip)	Pyg	SS_Pyg_Victim2Done			https://static.gosunoob.com/img/1/2015/07/Batman_Arkham_Knight_The_Perfect_Crime_Bleake_Island_1-1024x576.jpg	
 Breakable Shield (Bleake Island, SEBridgePanessa)	Breakable Objects	PickedUp_CityZ_MilitiaShield_12 			https://static.gosunoob.com/img/1/2015/06/militia-shields-locations-bleake-island-gotham-1024x576.jpg	
-Breakable Shield (Bleake Island, SionisCrane)	Breakable Objects	PickedUp_CityZ_MilitiaShield_8 			https://static.gosunoob.com/img/1/2015/06/gotham-city-militia-shields-map-locations-1024x576.jpg	
 Riddler Trophy (Bleake, Kord building Near GCPD)	Riddler Trophies	PickedUp_CityZ_Pickup_26 			https://static.gosunoob.com/img/1/2015/06/kord-riddler-trophy-arkham-knight-1024x576.jpg	
-Breakable Shield (Bleake Island, Kord building near GCPD)	Breakable Objects	PickedUp_CityZ_MilitiaShield_7 			https://static.gosunoob.com/img/1/2015/06/arkham-knight-collectible-militia-shield-250x140.jpg	
 IvyToGCPD	Main Story	Ch1bc_CityZ_Gordon_Ivy_Convo_done 				
 Riddler Trophy (Bleake Island, GCPD)	Riddler Trophies	PickedUp_CityZ_Pickup_30 			https://static.gosunoob.com/img/1/2015/06/arkham-knight-riddler-trophy-gcpd-250x140.jpg	
-Cash's Desk Riddle	Riddles	PickedUp_CityZ_Riddler_7 			https://static.gosunoob.com/img/1/2015/06/arkham-knight-riddle-solution-aaron-cash-1024x576.jpg	
 Jack Ryder Riddle	Riddles	PickedUp_CityZ_Riddler_19 			https://static.gosunoob.com/img/1/2015/06/bleake-island-riddle-solution-jack-ryder-1024x576.jpg	
 Breakable Shield (Bleake, BuildingNextToClockTower/Railway)	Breakable Objects	PickedUp_CityZ_MilitiaShield_14 			https://static.gosunoob.com/img/1/2015/06/batman-arkham-knight-militia-shields-locations-1024x576.jpg	
 Breakable Shield (Bleake, BuildingNorthofClockTower)	Breakable Objects	PickedUp_CityZ_MilitiaShield_6 			https://static.gosunoob.com/img/1/2015/06/militia-shields-locations-bleake-island-1024x576.jpg	
@@ -46,9 +43,6 @@ Riddler Trophy (Bleake Island, Ace lighthouse)	Riddler Trophies	PickedUp_CityZ_P
 Riddler Trophy (Bleake Island, UnderAceBridge)	Riddler Trophies	PickedUp_CityZ_Pickup_28 			https://static.gosunoob.com/img/1/2015/06/riddler-trophy-ace-chemicals-1024x576.jpg	
 Ace Chemicals (Main Story)	Main Story	ACE_Ch3_BridgeDestroyed 				
 Riddler Trophy (Bleake Island, Shoot Wall NearAce)	Riddler Trophies	PickedUp_CityZ_Pickup_27 			https://static.gosunoob.com/img/1/2015/06/bleake-island-riddler-trophy-batman-1024x576.jpg	
-Riddler Trophy (Bleake Island, WinchDrawerNearAce)	Riddler Trophies	PickedUp_CityZ_Pickup_10 			https://static.gosunoob.com/img/1/2015/06/ace-chemicals-riddler-trophy-1024x576.jpg	
-Breakable Shield (Bleake Island, BuildingNearRiddlerTrophy)	Breakable Objects	PickedUp_CityZ_MilitiaShield_5 			https://static.gosunoob.com/img/1/2015/06/batman-arkham-knight-militia-shields-1024x576.jpg	
-Breakable Shield (Bleake Island, Urbarail)	Breakable Objects	PickedUp_CityZ_MilitiaShield_4 			https://static.gosunoob.com/img/1/2015/06/arkham-knight-militia-emblem-map-location-1024x576.jpg	
 Riddler Bomb (Bleake, Chinatown Skyway)	Riddler Bomb	BombRiot_Z16_Succeeded 			https://static.gosunoob.com/img/1/2015/06/Batman_Arkham_Knight_Riddler_Victim_Bleake_Island_1-1024x576.jpg	
 Firemen (Bleake Island, Chinatown)	Firemen	SS_FireCrew_9_Rescued 			https://static.gosunoob.com/img/1/2015/07/Batman_Arkham_Knight_Firefighter_Location_in_Chinatown-1024x576.jpg	
 Riddler Trophy (Bleake Island, WinchNearClockTower)	Riddler Trophies	PickedUp_CityZ_Pickup_7 			https://static.gosunoob.com/img/1/2015/06/arkham-knight-bleake-island-puzzle-trophy-1024x576.jpg	
@@ -61,7 +55,7 @@ Escort Gordon to Clock Tower (Main Story)	Main Story	Ch3a_CityZ_Protect_Gordon_C
 Riddler Trophy (Bleake, GothamGas Near Panessa Bridge)	Riddler Trophies	PickedUp_CityZ_Pickup_4 			https://static.gosunoob.com/img/1/2015/06/gotham-gas-puzzle-trophy-1024x576.jpg	
 Track Oracle (Main Story)	Main Story	Ch3b_TireTrailActive 				
 First Bomb (Part of main story)	Bombs	SS_CommandBeacons_CityZ_15_ChD1_Ch3456789_LOD1.RCommandBeacon_1_destroyed 				
-Breakable Shield (Bleake Island, GCPD)	Breakable Objects	PickedUp_CityZ_MilitiaShield_15 			https://static.gosunoob.com/img/1/2015/06/bak-collectible-militia-shields-1024x576.jpg	
+Breakable Shield (Bleake Island, SionisCrane)	Breakable Objects	PickedUp_CityZ_MilitiaShield_8 			https://static.gosunoob.com/img/1/2015/06/gotham-city-militia-shields-map-locations-1024x576.jpg	
 Riddler Trophy (Miagani Island, UnderMercyBridge)	Riddler Trophies	PickedUp_CityX_Pickup_27 			https://static.gosunoob.com/img/1/2015/06/batman-arkham-knight-riddler-trophy-miagani-island-gcpd-1024x576.jpg	
 Riddler Trophy (Miagani, Shoot Wall MercyBridge with Bmobile)	Riddler Trophies	PickedUp_CityX_Pickup_24 			https://static.gosunoob.com/img/1/2015/06/miagani-harbor-riddler-trophy-location-1024x576.jpg	
 Pyg (Miagani, NearMercyBridge; Chest Arm Toe)	Pyg	SS_Pyg_Victim3Done 			https://static.gosunoob.com/img/1/2015/07/Miagani_Island_The_Perfect_Crime_Batman_Arkham_Knight_1-1024x576.jpg	
@@ -82,15 +76,17 @@ Firemen (Miagani Island, Gotham Herald)	Firemen	SS_FireCrew_5_Rescued 			https:/
 Riddler Bomb (Miagani Island, NearParking)	Riddler Bomb	BombRiot_X14_Succeeded 			https://static.gosunoob.com/img/1/2015/07/Riddler_Victim_Batman_Arkham_Knight_Miagani_Island_1-1024x576.jpg	
 Tank Head Shot Upgrade	Upgrades	Unlocked_BmblHeavyCannonHeadShot 				
 Vulcan Stabalizer Upgrade	Upgrades	Unlocked_BmblVulcanGunAccuracy				
+Breakable Shield (Bleake Island, Kord building near GCPD)	Breakable Objects	PickedUp_CityZ_MilitiaShield_7 			https://static.gosunoob.com/img/1/2015/06/arkham-knight-collectible-militia-shield-250x140.jpg	
+Breakable Shield (Bleake Island, GCPD)	Breakable Objects	PickedUp_CityZ_MilitiaShield_15 			https://static.gosunoob.com/img/1/2015/06/bak-collectible-militia-shields-1024x576.jpg	
 Breakable Shield (Miagani Island, BankOfGotham)	Breakable Objects	PickedUp_CityX_MilitiaShield_14 			https://resource.supercheats.com/library/300w/batman-arkham-knight/BO_Miagani12B.jpg	
-Breakable Shield (Miagani Island, AcrossParkingGarage)	Breakable Objects	PickedUp_CityX_MilitiaShield_15 			https://resource.supercheats.com/library/300w/batman-arkham-knight/BO_Miagani13B.jpg	
+League of Assassin's Riddle (Miagani Alley Parking Lot Entrance)	Riddles	PickedUp_CityX_Riddler_32 			https://static.gosunoob.com/img/1/2015/06/miagani-island-underpass-riddle-1024x576.jpg	
 Breakable Shield (Miagani Island, Koul Brau Near Parking)	Breakable Objects	PickedUp_CityX_MilitiaShield_1 			https://resource.supercheats.com/library/300w/batman-arkham-knight/BO_Miagani14B.jpg	
+Breakable Shield (Miagani Island, AcrossParkingGarage)	Breakable Objects	PickedUp_CityX_MilitiaShield_15 			https://resource.supercheats.com/library/300w/batman-arkham-knight/BO_Miagani13B.jpg	
 Riddler Trophy (Miagani Island, Gotham Casino)	Riddler Trophies	PickedUp_CityX_Pickup_25 			https://static.gosunoob.com/img/1/2015/06/gotham-casino-riddler-trophy-bak-1024x576.jpg	
 Breakable Shield (Miagani Island, Pumpkin Near Casino)	Breakable Objects	PickedUp_CityX_MilitiaShield_2 			https://www.gamerguides.com/batman-arkham-knight/guide/collectibles-guide/miagani-island-collectible-locations/breakable-object-locations	
 Bomb (Miagani Island, Botanical Gardens Overpass)	Bombs	SS_CommandBeacons_CityX_09_ChD1ab_Ch3456789.RCommandBeacon_0_destroyed			https://static.gosunoob.com/img/1/2015/07/arkham-knight-miagani-island-landmine-1024x576.jpg	
 Breakable Shield (Miagani Island, NextToOracleCrash)	Breakable Objects	PickedUp_CityX_MilitiaShield_3 			https://resource.supercheats.com/library/300w/batman-arkham-knight/BO_Miagani1B.jpg	
 Investigate Oracle Crash	Main Story	Ch3_CityX_08_APC_Forensics_Complete				
-Breakable Shield (Miagani Island, BuildingNearNewtonFairgrounds)	Breakable Objects	PickedUp_CityX_MilitiaShield_5 			https://resource.supercheats.com/library/300w/batman-arkham-knight/BO_Miagani3B.jpg	
 Firefly (Miagani Island, Bristol Fire Station near Fairgrounds)	Firefly	SS_Firefly_CityX_Complete 			https://static.gosunoob.com/img/1/2015/07/miagani-island-bristol-fire-station-1024x576.jpg	
 Azrael 1 (Near Parking, use map)	Azrael	SS_Azrael_Fight1_Complete 				
 Riddler Trophy (Miagani Island, Diner Near Parking Lot)	Riddler Trophies	PickedUp_CityX_Pickup_33 			https://static.gosunoob.com/img/1/2015/06/arkham-knight-riddler-trophy-paulis-diner-250x140.jpg	
@@ -111,22 +107,21 @@ Miagani Tunnel System Entrance	Main Story	CityX_T10_Ch3c_Tunnel_WinchUsed
 Riddler Trophy (Miagani Island, Tunnel system)	Riddler Trophies	PickedUp_CityX_Pickup_32 				
 Miagani Tunnel Done	Main Story	CityX_T10_Tunnel_Cleared 				
 Batmobile Upgrade	Main Story	Batmobile_Secondary_Weapon_Generator_Given 				
-APC 1	APC	SS_APC_APC1Complete 				
-Grapnel Boost Mk3 Upgrade	Upgrades	Unlocked_GrappleBoostMk3				
-Breakable Shield (Miagani Island, Mercy Bridge)	Breakable Objects	PickedUp_CityX_MilitiaShield_13 			https://resource.supercheats.com/library/300w/batman-arkham-knight/BO_Miagani11B.jpg	
+Riddler Trophy (Miagani Island, ChurchNearPenguinTruck)	Riddler Trophies	PickedUp_CityX_Pickup_35 			https://static.gosunoob.com/img/1/2015/06/riddler-trophy-miagani-island-church-1024x576.jpg	
 Breakable Shield (Miagani, DolphinBuildingNearPenguinTruck)	Breakable Objects	PickedUp_CityX_MilitiaShield_12 				
 Breakable Shield (Miagani Island, OverpassNearDolphinBuilding)	Breakable Objects	PickedUp_CityX_MilitiaShield_11 				
+Breakable Shield (Miagani Island, Mercy Bridge)	Breakable Objects	PickedUp_CityX_MilitiaShield_13 			https://resource.supercheats.com/library/300w/batman-arkham-knight/BO_Miagani11B.jpg	
+Firemen (Miagani Island, Mercy Bridge)	Firemen	SS_FireCrew_8_Rescued 			https://static.gosunoob.com/img/1/2015/07/Batman_Arkham_Knight_The_Line_of_Duty_Miagani_Island-1024x576.jpg	
+APC 1	APC	SS_APC_APC1Complete 				
 Penguin Start	Main Story	CityX6_Ch3d_PenguinCacheEntered				
-Riddler Trophy (Miagani Island, ChurchNearPenguinTruck)	Riddler Trophies	PickedUp_CityX_Pickup_35 			https://static.gosunoob.com/img/1/2015/06/riddler-trophy-miagani-island-church-1024x576.jpg	
 First Cache Destroyed (Near Parking)	Main Story	Penguin_Cache_Completed 				
 Riddler Trophy (Miagani Island, GarageJump)	Riddler Trophies	PickedUp_CityX_Pickup_1 			https://static.gosunoob.com/img/1/2015/06/riddler-puzzle-trophy-parking-roof-1024x576.jpg	
-League of Assassin's Riddle (Miagani Alley Parking Lot Entrance)	Riddles	PickedUp_CityX_Riddler_32 			https://static.gosunoob.com/img/1/2015/06/miagani-island-underpass-riddle-1024x576.jpg	
 APC 2	APC	SS_APC_APC2Complete 				
-Firemen (Miagani Island, Mercy Bridge)	Firemen	SS_FireCrew_8_Rescued 			https://static.gosunoob.com/img/1/2015/07/Batman_Arkham_Knight_The_Line_of_Duty_Miagani_Island-1024x576.jpg	
 Firefly (Bleake Island, Fire Station by Water Near GCPD)	Firefly	SS_Firefly_CityZ_Complete 			https://static.gosunoob.com/img/1/2015/07/bleake-island-cauldron-fire-station-1024x576.jpg	
+Grapnel Boost Takedown Upgrade	Upgrades	Unlocked_GrappleBoostTd 				
+Grapnel Boost Mk3 Upgrade	Upgrades	Unlocked_GrappleBoostMk3				
 Riddler Challenge 1 (Bleake, Auto Repair [or use map] 0 3)	Riddler Mission	Orphan_C2_Done 			https://static.gosunoob.com/img/1/2015/07/Batman_Arkham_Knight_Balancing_Act_Riddlers_Revenge-1024x576.jpg	
 Riddler Trophy (Founders Island, Lighthouse)	Riddler Trophies	PickedUp_CityY_Pickup_35 			https://static.gosunoob.com/img/1/2015/06/batman-arkham-knight-riddler-trophies-ace-chemicals-1024x576.jpg	
-Riddler Trophy (Founders, Wooden Wall Near fireman)	Riddler Trophies	PickedUp_CityY_Pickup_20 			https://static.gosunoob.com/img/1/2015/06/founders-island-riddler-trophies-trade-house-1024x576.jpg	
 Firemen (FoundersIsland, Lighthouse)	Firemen	SS_FireCrew_10_Rescued 			https://static.gosunoob.com/img/1/2015/07/Batman_Arkham_Knight_Missing_Firefighter_Founders_Island-1024x576.jpg	
 Stagg Watchtower	Main Story	Ch4_FirstWatchTower_Complete 				
 Riddler Trophy (Founders Island, Wayne Plaza)	Riddler Trophies	PickedUp_CityY_Pickup_25 			https://static.gosunoob.com/img/1/2015/06/wayne-plaza-riddler-trophy-1024x576.jpg	
@@ -168,16 +163,15 @@ Oracle Dies	Main Story	Ch5a_CityZ_07_OracleDead
 Riddler Trophy (Bleake, Chinatown Rooftop 9 Robot Fight)	Riddler Trophies	PickedUp_CityZ_Pickup_14 			https://static.gosunoob.com/img/1/2015/06/fighting-riddler-trophy-bleake-island-1024x576.jpg	
 Riddler Bomb (Bleake, Near Clock Tower and Rail Tracks)	Riddler Bomb	BombRiot_Z18_Succeeded 			https://static.gosunoob.com/img/1/2015/06/Bleake_Island_Riddler_Victim_Batman_Arkham_Knight_11-1024x576.jpg	
 APC 3	APC	SS_APC_APC3Complete 				
+Cash's Desk Riddle	Riddles	PickedUp_CityZ_Riddler_7 			https://static.gosunoob.com/img/1/2015/06/arkham-knight-riddle-solution-aaron-cash-1024x576.jpg	
+GCPD/Ivy/Cobras	Main Story	Ch5b_CityZ_17_Heavy_Tank_Scanning_Complete 				
 Reload Speed 2 Upgrade	Upgrades	Unlocked_BmblHeavyCannonReload2 				
 Cobra Lure Upgrade	Upgrades	Unlocked_BmblHeavyCannonLure				
 Tank Emergency Energy Upgrade	Upgrades	Unlocked_BmblGeneratorShielding1				
 Tank Energy Absorption Upgrade	Upgrades	Unlocked_BmblEnergyAbsorbtion1 				
-GCPD/Ivy/Cobras	Main Story	Ch5b_CityZ_17_Heavy_Tank_Scanning_Complete 				
 Riddler Trophy (Miagani, Hospital Scan)	Riddler Trophies	PickedUp_CityX_Pickup_18 			https://static.gosunoob.com/img/1/2015/06/hospital-riddler-trophy-scan-miagani-island-1024x576.jpg	
 Checkpoint (Miagani, Near Orphanage)	Checkpoints	Checkpoint_X_KDestroyed 			https://static.gosunoob.com/img/1/2015/07/Batman_Arkham_Knight_Own_the_Roads_Miagani_Island_1-1024x576.jpg	
 Riddler Trophy (Miagani, next to checkpoint)	Riddler Trophies	PickedUp_CityX_Pickup_4 			https://guides.gamepressure.com/batmanarkhamknight/gfx/word/428455578.jpg	
-Pyg (Miagani, NearFoundersIsland; Torso Eye Arm)	Pyg	SS_Pyg_Victim4Done 			https://static.gosunoob.com/img/1/2015/07/Batman_Arkham_Knight_Mutilated_Body_Miagani_Island_1-1024x576.jpg	
-Watchtower (Miagani, Near Bridge By Orphanage)	Watchtower	SS_Watchtowers_CityX_28_ChX1_Ch56789_LOD1.RRadarTower_12_destroyed 			https://static.gosunoob.com/img/1/2015/07/miagani-island-militia-watchtower-1024x576.jpg	
 Breakable Shield (Miagani, Orphanage)	Breakable Objects	PickedUp_CityX_MilitiaShield_4 			https://resource.supercheats.com/library/300w/batman-arkham-knight/BO_Miagani2B.jpg	
 Riddler Trophy (Miagani, Orphanage)	Riddler Trophies	PickedUp_CityX_Pickup_2 			https://static.gosunoob.com/img/1/2015/06/orphanage-puzzle-trophy-miagani-island-1024x576.jpg	
 Riddler Orphanage 2 (B: 31452; C:13524)	Riddler Mission	Orphan_01_Complete 				
@@ -186,8 +180,8 @@ Checkpoint (Miagani, North NearWater Across Lady Gotham)	Checkpoints	Checkpoint_
 Riddler Challenge 2 (Miagani, Casino [or use map] 0 1)	Riddler Mission	Orphan_C3_Done 			https://static.gosunoob.com/img/1/2015/07/Batman_Arkham_Knight_Flight_School_Riddlers_Revenge-1024x576.jpg	
 Watchtower (Miagani, Hospital [2 consoles])	Watchtower	SS_Watchtowers_CityX_04_ChX1_Ch56789_LOD1.RRadarTower_2_destroyed 			https://static.gosunoob.com/img/1/2015/07/hospital-militia-watchtower-miagani-island-1024x576.jpg	
 Riddler Orphanage 3 	Riddler Mission	Orphan_04_Complete 				
-Tank Energy Storage Protection Upgrade	Upgrades	Unlocked_BmblGeneratorShielding2				
 Bomb (Miagani Island, Botanical Gardens)	Bombs	SS_CommandBeacons_CityX_14_ChD1ab_Ch56789.RCommandBeacon_5_destroyed 			https://static.gosunoob.com/img/1/2015/07/campaign-for-disarmament-miagani-island-1024x576.jpg	
+Breakable Shield (Miagani Island, BuildingNearNewtonFairgrounds)	Breakable Objects	PickedUp_CityX_MilitiaShield_5 			https://resource.supercheats.com/library/300w/batman-arkham-knight/BO_Miagani3B.jpg	
 Riddler Bomb (Miagani, Near Wayne Tower)	Riddler Bomb	BombRiot_X15_Succeeded 			https://static.gosunoob.com/img/1/2015/07/Batman_Arkham_Knight_Riddler_Victim_Miagani_Island_1-1024x576.jpg	
 Breakable Shield (Miagani, Side of Wayne Tower)	Breakable Objects	PickedUp_CityX_MilitiaShield_8 			https://resource.supercheats.com/library/300w/batman-arkham-knight/BO_Miagani6B.jpg	
 Firemen (Miagani, Wayne Tower)	Firemen	SS_FireCrew_4_Rescued 			https://static.gosunoob.com/img/1/2015/07/Batman_Arkham_Knight_Firefighter_Location_Miagani_Island-1024x576.jpg	
@@ -208,46 +202,35 @@ Penguin 1 (Falcone)	Penguin	PenguinCache_C2_Thugs_Done
 Bat Symbol Riddle	Riddles	PickedUp_CityZ_Riddler_15     			https://static.gosunoob.com/img/1/2015/06/bak-riddles-collectible-1024x576.jpg	
 Lady of Gotham Riddle	Riddles	PickedUp_CityZ_Riddler_22     			https://static.gosunoob.com/img/1/2015/06/arkham-knight-bleake-island-statue-riddle-1024x576.jpg	
 Arkham Asylum Riddle	Riddles	PickedUp_CityZ_Riddler_21 			https://static.gosunoob.com/img/1/2015/06/batman-arkham-knight-riddles-bleake-island-1024x576.jpg	
-Wonder Tower Riddle	Riddles	PickedUp_CityX_Riddler_2 			https://static.gosunoob.com/img/1/2015/06/miagani-riddle-wayne-tower-1024x576.jpg	
 Bomb (Bleake, Outside Falcone Penguin Cache)	Bombs	SS_CommandBeacons_CityZ_19_ChD1ab_Ch3456789.RCommandBeacon_1_destroyed 			https://static.gosunoob.com/img/1/2015/07/bleake-island-explosive-device-1024x576.jpg	
 Riddler Trophy (Bleake, Falcone Drag Question Marks)	Riddler Trophies	PickedUp_CityZ_Pickup_6 			https://static.gosunoob.com/img/1/2015/06/underpass-riddler-trophy-1024x576.jpg	
 Fear Takedown x4 Upgrade	Upgrades	Unlocked_4FearTakedowns				
 Fear Takedown x5 Upgrade	Upgrades	Unlocked_5FearTakedowns 				
+Grapnel Boost Mk4 Upgrade	Upgrades	Unlocked_GrappleBoostMk4 				
 Firemen (Bleake, Dock SouthEastBleake)	Firemen	SS_FireCrew_12_Rescued 			https://static.gosunoob.com/img/1/2015/07/The_Line_of_Duty_Firefighter_Arkham_Knight_Bleake_Island_Batman-1024x576.jpg	
 Firemen (Bleake, EastBleake)	Firemen	SS_FireCrew_2_Rescued 			https://static.gosunoob.com/img/1/2015/07/The_Line_of_Duty_Firefighter_Bleake_Island_Batman_Arkham_Knight-1024x576.jpg	
 Riddler Trophy (Bleake, ImpossibleSpringEastBleak)	Riddler Trophies	PickedUp_CityZ_Pickup_1 			https://static.gosunoob.com/img/1/2015/06/riddler-trophy-pinball-bleake-island-1024x576.jpg	
 Riddler Trophy (Bleake, ExplosiveGelShippingContainer)	Riddler Trophies	PickedUp_CityZ_Pickup_3 			https://static.gosunoob.com/img/1/2015/06/container-riddler-puzzle-trophy-bleake-island-1024x576.jpg	
 Collect Freeze Blast	Gadget	Equip_FreezeSpray 				
-Robin Riddle (Panessa)	Riddles	PickedUp_Film_Riddler_37 				
 Riddler Trophy (Bleake, StartOnPanessaRoof Race)	Riddler Trophies	PickedUp_CityZ_Pickup_20 			https://static.gosunoob.com/img/1/2015/06/panessa-studios-time-trial-puzzle-trophy-1024x576.jpg	
 Manbat Lab (use map)	ManBat	SS_ManBat_CreatedCure 				
 Manbat Riddle	Riddles	PickedUp_CityZ_Riddler_25 				
-Two Face Bank 1 (Bleake)	Two Face	Bank01_Empty 				
+Riddler Trophy (Bleake Island, WinchDrawerNearAce)	Riddler Trophies	PickedUp_CityZ_Pickup_10 			https://static.gosunoob.com/img/1/2015/06/ace-chemicals-riddler-trophy-1024x576.jpg	
+Breakable Shield (Bleake Island, BuildingNearRiddlerTrophy)	Breakable Objects	PickedUp_CityZ_MilitiaShield_5 			https://static.gosunoob.com/img/1/2015/06/batman-arkham-knight-militia-shields-1024x576.jpg	
+Breakable Shield (Bleake Island, Urbarail)	Breakable Objects	PickedUp_CityZ_MilitiaShield_4 			https://static.gosunoob.com/img/1/2015/06/arkham-knight-militia-emblem-map-location-1024x576.jpg	
 Riddler Trophy (Bleake, ScanNearTwoFaceBank)	Riddler Trophies	PickedUp_CityZ_Pickup_21 			https://static.gosunoob.com/img/1/2015/06/urbarail-station-riddler-trophy-1024x576.jpg	
-Riddler Trophy (Founders, ShackNearWaterUnderRail)	Riddler Trophies	PickedUp_CityY_Pickup_24 			https://static.gosunoob.com/img/1/2015/06/arkham-knight-riddler-trophies-founders-island-1024x576.jpg	
 Checkpoint (Founders, NearBleakeBridgeAndWater)	Checkpoints	Checkpoint_Y_NDestroyed 			https://static.gosunoob.com/img/1/2015/07/Batman_Arkham_Knight_Own_the_Roads_Founders_Island_2-1024x576.jpg	
 Watchtower (Founders, ContinueAlongWater)	Watchtower	SS_Watchtowers_CityY_10_ChX1_Ch3456789_LOD1.RRadarTower_15_destroyed 			https://static.gosunoob.com/img/1/2015/07/bruford-tower-militia-watchtower-1024x576.jpg	
 Riddler Trophy (Founders, ByDockNextToBridge)	Riddler Trophies	PickedUp_CityY_Pickup_8 			https://static.gosunoob.com/img/1/2015/06/founders-island-riddler-trophy-bak-riverside-1024x576.jpg	
 Checkpoint (Founders, ContinueAlongWater)	Checkpoints	Checkpoint_Y_LDestroyed 			https://static.gosunoob.com/img/1/2015/07/Batman_Arkham_Knight_Own_the_Roads_Founders_Island_1-1024x576.jpg	
 Watchtower (Founders, Continue Near Dock)	Watchtower	SS_Watchtowers_CityY_15_ChX1_Ch3456789_LOD1.RRadarTower_1_destroyed 			https://static.gosunoob.com/img/1/2015/07/dock-militia-watchtower-founders-island-1024x576.jpg	
 Checkpoint (Founders, AmertekNearNorthMiaganiBridge)	Checkpoints	Checkpoint_Y_PDestroyed 			https://static.gosunoob.com/img/1/2015/07/Batman_Arkham_Knight_Own_the_Roads_Founders_Island_7-1024x576.jpg	
-Watchtower (Founders, Continue To Water)	Watchtower	SS_Watchtowers_CityY_18_ChX1_Ch3456789_LOD1.RRadarTower_20_destroyed 			https://static.gosunoob.com/img/1/2015/07/founders-island-watchtower-side-mission-1024x576.jpg	
-Grapnel Boost Mk4 Upgrade	Upgrades	Unlocked_GrappleBoostMk4 				
-Riddler Trophy (Founders, Pier North Miagani Bridge)	Riddler Trophies	PickedUp_CityY_Pickup_32 			https://static.gosunoob.com/img/1/2015/06/founders-island-riddler-trophy-pier-1024x576.jpg	
-Checkpoint (Founders, ContinueAlongWater)	Checkpoints	Checkpoint_Y_QDestroyed 			https://static.gosunoob.com/img/1/2015/07/Batman_Arkham_Knight_Own_the_Roads_Founders_Island_8-1024x576.jpg	
-Riddler Trophy (Founders, TowerNearMonuments)	Riddler Trophies	PickedUp_CityY_Pickup_31 			https://static.gosunoob.com/img/1/2015/06/founders-monument-riddler-trophy-1024x576.jpg	
-Watchtower (Founders, NearPortAdams)	Watchtower	SS_Watchtowers_CityY_17_ChX1_Ch3456789_LOD1.RRadarTower_19_destroyed 			https://static.gosunoob.com/img/1/2015/07/militia-watchtower-location-founders-island-1024x576.jpg	
 Drone + Radar 1 (Main Story)	Main Story	Ch5c_CityY_Radar_1_Destroyed 				
-Watchtower (Founders, West Cobblepot [away from marker])	Watchtower	SS_Watchtowers_CityY_12_ChX1_Ch56789_LOD1.RRadarTower_0_destroyed 			https://static.gosunoob.com/img/1/2015/07/cobblepot-manor-militia-watchtower-1024x576.jpg	
-Penguin Manor Riddle	Riddles	PickedUp_CityY_Riddler_29 			https://static.gosunoob.com/img/1/2015/06/arkham-knight-founders-island-riddle-penguin-1024x576.jpg	
-Goth Corp Riddle	Riddles	PickedUp_CityY_Riddler_14 			https://static.gosunoob.com/img/1/2015/06/bak-riddle-founders-island-freeze-1024x576.jpg	
 Watchtower (Founders, North West [Near Marker])	Watchtower	SS_Watchtowers_CityY_08_ChX1_Ch3456789_LOD1.RRadarTower_0_destroyed 			https://static.gosunoob.com/img/1/2015/07/founders-island-militia-watchtower-1024x576.jpg	
+Riddler Trophy (Founders, LexCorpBuilding)	Riddler Trophies	PickedUp_CityY_Pickup_12 			https://static.gosunoob.com/img/1/2015/06/synthesizer-puzzle-founders-island-1024x576.jpg	
 Radar 2 (Main Story)	Main Story	Ch5c_CityY_Radar_2_Destroyed 				
-Firemen (Founders, MiddleRaisedPlatform)	Firemen	SS_FireCrew_7_Rescued 			https://static.gosunoob.com/img/1/2015/07/Missing_Firefighter_Founders_Island_Batman_Arkham_Knight-1024x576.jpg	
 Long Range Missle Launcher (Main Story)	Main Story	CityY_Missile_Launcher_2_Dead 				
 Riddler Trophy (Founders, Under Raised Ramp LexCorp)	Riddler Trophies	PickedUp_CityY_Pickup_29 			https://static.gosunoob.com/img/1/2015/06/arkham-knight-city-vision-riddler-trophy-1024x576.jpg	
-Breakable Shield (Founders, UnderWalkwayNearRamp)	Breakable Objects	PickedUp_CityY_MilitiaShield_5 			https://resource.supercheats.com/library/300w/batman-arkham-knight/BO_Founders11B.jpg	
-Breakable Shield (Founders, EastLowerStreetNearChurch)	Breakable Objects	PickedUp_CityY_MilitiaShield_6 			https://resource.supercheats.com/library/300w/batman-arkham-knight/BO_Founders1B.jpg	
 Church Riddle	Riddles	PickedUp_CityY_Riddler_3 			https://static.gosunoob.com/img/1/2015/06/founders-island-azrael-riddle-1024x576.jpg	
 Pyg (Founders, EastNearWater; leg abdomen skull)	Pyg	SS_Pyg_Victim5Done 			https://static.gosunoob.com/img/1/2015/07/Batman_Arkham_Knight_Unidentified_Body_The_Perfect_Crime_1-1024x576.jpg	
 Breakable Shield (Founders, CityvisionConstruction)	Breakable Objects	PickedUp_CityY_MilitiaShield_4 			https://resource.supercheats.com/library/300w/batman-arkham-knight/BO_Founders2B.jpg	
@@ -261,11 +244,17 @@ Halloween Riddle (Up Above)	Riddles	PickedUp_CityY_Riddler_6 			https://static.g
 Riddler Trophy (Founders, ScanNearHalloweenRiddle)	Riddler Trophies	PickedUp_CityY_Pickup_17 			https://static.gosunoob.com/img/1/2015/06/riddler-trophy-underground-scanner-1024x576.jpg	
 Riddler Trophy (Founders, ByNMiaganiBridge ElectricPuzzle)	Riddler Trophies	PickedUp_CityY_Pickup_2 			https://static.gosunoob.com/img/1/2015/06/founders-island-puzzle-trophy-sliding-generators-1024x576.jpg	
 Riddler Challenge 3 (Founders, use map 2 1)	Riddler Mission	Orphan_C4_ReturnedPostCompletion 				
+Checkpoint (Founders, ContinueAlongWater)	Checkpoints	Checkpoint_Y_QDestroyed 			https://static.gosunoob.com/img/1/2015/07/Batman_Arkham_Knight_Own_the_Roads_Founders_Island_8-1024x576.jpg	
+Riddler Trophy (Founders, Pier North Miagani Bridge)	Riddler Trophies	PickedUp_CityY_Pickup_32 			https://static.gosunoob.com/img/1/2015/06/founders-island-riddler-trophy-pier-1024x576.jpg	
+Watchtower (Founders, Continue To Water)	Watchtower	SS_Watchtowers_CityY_18_ChX1_Ch3456789_LOD1.RRadarTower_20_destroyed 			https://static.gosunoob.com/img/1/2015/07/founders-island-watchtower-side-mission-1024x576.jpg	
 Bomb (Founders, SE Intersection near Bank)	Bombs	SS_CommandBeacons_CityY_17_ChD1ab_Ch3456789.RCommandBeacon_4_destroyed 			https://static.gosunoob.com/img/1/2015/07/campaign-for-disarmament-founders-island-1024x576.jpg	
-Two Face Bank 2 (Founders)	Two Face	Bank02_Empty 				
 Riddler Trophy (Founders, Near Bank Kord Monument Skyway)	Riddler Trophies	PickedUp_CityY_Pickup_21 			https://static.gosunoob.com/img/1/2015/06/arkham-knight-riddler-trophy-monument-1024x576.jpg	
 Breakable Shield (Founders, OtisburgPlazaNearPortAdamsDoor)	Breakable Objects	PickedUp_CityY_MilitiaShield_1 			https://resource.supercheats.com/library/300w/batman-arkham-knight/BO_Founders7B.jpg	
+Riddler Trophy (Founders, TowerNearMonuments)	Riddler Trophies	PickedUp_CityY_Pickup_31 			https://static.gosunoob.com/img/1/2015/06/founders-monument-riddler-trophy-1024x576.jpg	
 Azrael 2 (near firefly, use map)	Azrael	SS_Azrael_Fight2_Complete				
+Goth Corp Riddle	Riddles	PickedUp_CityY_Riddler_14 			https://static.gosunoob.com/img/1/2015/06/bak-riddle-founders-island-freeze-1024x576.jpg	
+Watchtower (Founders, West Cobblepot [away from marker])	Watchtower	SS_Watchtowers_CityY_12_ChX1_Ch56789_LOD1.RRadarTower_0_destroyed 			https://static.gosunoob.com/img/1/2015/07/cobblepot-manor-militia-watchtower-1024x576.jpg	
+Penguin Manor Riddle	Riddles	PickedUp_CityY_Riddler_29 			https://static.gosunoob.com/img/1/2015/06/arkham-knight-founders-island-riddle-penguin-1024x576.jpg	
 Afterburner Recharge 1	Upgrades	Unlocked_BmblBoostCharge1				
 Afterburner Recharge 2	Upgrades	Unlocked_BmblBoostCharge2				
 Breakable Shield (Founders, Behind Firefly)	Breakable Objects	PickedUp_CityY_MilitiaShield_3 			https://resource.supercheats.com/library/300w/batman-arkham-knight/BO_Founders5B.jpg	
@@ -282,6 +271,9 @@ Drone Hack 2 Upgrade	Upgrades	Unlocked_RHDDroneHackMK2
 Sabatoge Drone Controller Upgrade	Upgrades	Unlocked_DisruptorMiniDroneCont				
 Smoke Pellet Duration Upgrade	Upgrades	Unlocked_SmokePelletDuration 				
 Smoke Pellet Area Upgrade	Upgrades	Unlocked_SmokePelletAOE				
+Special Combo Batarang upgrade	Upgrades	Unlocked_SpecialComboBatarang				
+Combo Boost Upgrade	Upgrades	Unlocked_SpecialMoveCost				
+Robin Riddle (Panessa)	Riddles	PickedUp_Film_Riddler_37 				
 Riddler Trophy (Panessa, ElectricBatarang)	Riddler Trophies	PickedUp_Film_Pickup_26 			https://static.gosunoob.com/img/1/2015/06/panessa-studios-riddler-trophy-locations-1024x576.jpg	
 Riddler Trophy (Panessa, 8 9 10 12)	Riddler Trophies	PickedUp_Film_Pickup_27 			https://static.gosunoob.com/img/1/2015/06/puzzle-trophy-studios-solution-1024x576.jpg	
 Breakable (Panessa, BeforeEntrance)	Breakable Objects	PickedUp_Film_JackInTheBox_1 				
@@ -297,9 +289,6 @@ Riddler Trophy (Panessa, Stage B vent Switch)	Riddler Trophies	PickedUp_Film_Pic
 Breakable (Panessa, Stage B Vent 3)	Breakable Objects	PickedUp_Film_JackInTheBox_6 			https://resource.supercheats.com/library/300w/batman-arkham-knight/BO_Panessa13B.jpg	
 Riddler Trophy (Panessa, Stage B Vent Freeze Blast)	Riddler Trophies	PickedUp_Film_Pickup_41 			https://static.gosunoob.com/img/1/2015/06/panessa-studios-puzzle-trophy-1024x576.jpg	
 Riddler Trophy (Panessa, Fan)	Riddler Trophies	PickedUp_Film_Pickup_40 			https://static.gosunoob.com/img/1/2015/06/arkham-knight-studio-riddler-trophies-1024x576.jpg	
-Breakable (Panessa, Stage B First Entrance)	Breakable Objects	PickedUp_Film_JackInTheBox_12			https://resource.supercheats.com/library/300w/batman-arkham-knight/BO_Panessa5B.jpg	
-Joker Shrine Riddle (Panessa Stage A Entrance Left)	Riddles	PickedUp_Film_Riddler_16 				
-Riddler Trophy (Panessa, Stage A Entrance Right)	Riddler Trophies	PickedUp_Film_Pickup_30 			https://static.gosunoob.com/img/1/2015/06/stage-a-riddler-trophy-studios-1024x576.jpg	
 Riddler Trophy (Panessa, backStage A Robot)	Riddler Trophies	PickedUp_Film_Pickup_48 			https://static.gosunoob.com/img/1/2015/06/riddler-trophy-panessa-studios-robot-1024x576.jpg	
 Riddler Trophy (Panessa, backStage A Sentries)	Riddler Trophies	PickedUp_Film_Pickup_50 			https://static.gosunoob.com/img/1/2015/06/bak-riddler-trophy-turrets-1024x576.jpg	
 Inferno Riddle (Panessa backStage A Entrance Right)	Riddles	PickedUp_Film_Riddler_13 				
@@ -307,11 +296,15 @@ Breakable (Panessa, backStage A Entrance Right)	Breakable Objects	PickedUp_Film_
 Breakable (Panessa, backStage A Entrance Left)	Breakable Objects	PickedUp_Film_JackInTheBox_3 			https://resource.supercheats.com/library/300w/batman-arkham-knight/BO_Panessa15B.jpg	
 Riddler Trophy (Panessa, backStage A 124141)	Riddler Trophies	PickedUp_Film_Pickup_47 			https://static.gosunoob.com/img/1/2015/06/riddler-trophy-panessa-studio-color-puzzle-1024x576.jpg	
 Breakable (Panessa, Left of backStage A Entrance)	Breakable Objects	PickedUp_Film_JackInTheBox_11     			https://resource.supercheats.com/library/300w/batman-arkham-knight/BO_Panessa4B.jpg	
-Riddler Trophy (Panessa, Stage C 15732486)	Riddler Trophies	PickedUp_Film_Pickup_32 			https://static.gosunoob.com/img/1/2015/06/panessa-studios-riddler-trophy-generator-puzzle-1024x576.jpg	
-Riddler Trophy (Panessa, Stage C Exploding Gel Wall)	Riddler Trophies	PickedUp_Film_Pickup_35 			https://static.gosunoob.com/img/1/2015/06/arkham-knight-riddler-trophy-batarang-puzzle-1024x576.jpg	
+Joker Shrine Riddle (Panessa Stage A Entrance Left)	Riddles	PickedUp_Film_Riddler_16 				
+Riddler Trophy (Panessa, Stage A Entrance Right)	Riddler Trophies	PickedUp_Film_Pickup_30 			https://static.gosunoob.com/img/1/2015/06/stage-a-riddler-trophy-studios-1024x576.jpg	
 Breakable (Panessa, Stage C after door left)	Breakable Objects	PickedUp_Film_JackInTheBox_9     			https://resource.supercheats.com/library/300w/batman-arkham-knight/BO_Panessa8B.jpg	
+Riddler Trophy (Panessa, Stage C Exploding Gel Wall)	Riddler Trophies	PickedUp_Film_Pickup_35 			https://static.gosunoob.com/img/1/2015/06/arkham-knight-riddler-trophy-batarang-puzzle-1024x576.jpg	
+Breakable (Panessa, Before Stage C Door)	Breakable Objects	PickedUp_Film_JackInTheBox_13 			https://resource.supercheats.com/library/300w/batman-arkham-knight/BO_Panessa7B.jpg	
+Riddler Trophy (Panessa, Stage C 15732486)	Riddler Trophies	PickedUp_Film_Pickup_32 			https://static.gosunoob.com/img/1/2015/06/panessa-studios-riddler-trophy-generator-puzzle-1024x576.jpg	
 Breakable (Panessa, Stage C corridor going out)	Breakable Objects	PickedUp_Film_JackInTheBox_14 			https://resource.supercheats.com/library/300w/batman-arkham-knight/BO_Panessa6B.jpg	
 Breakable (Panessa, Next to robot)	Breakable Objects	PickedUp_Film_JackInTheBox_15     			https://resource.supercheats.com/library/300w/batman-arkham-knight/BO_Panessa3B.jpg	
+Breakable (Panessa, Stage B First Entrance)	Breakable Objects	PickedUp_Film_JackInTheBox_12			https://resource.supercheats.com/library/300w/batman-arkham-knight/BO_Panessa5B.jpg	
 Riddler Trophy (Bleake, Panessa Roof Robot)	Riddler Trophies	PickedUp_CityZ_Pickup_11 			https://static.gosunoob.com/img/1/2015/06/pressure-plate-riddler-trophy-bleake-island-1024x576.jpg	
 Riddler Trophy (Bleake, Column Near Upgrade)	Riddler Trophies	PickedUp_CityZ_Pickup_9 			https://static.gosunoob.com/img/1/2015/06/panessa-studios-square-riddler-trophy-solution-1024x576.jpg	
 Batmobile Upgrade/Trigger Hush	Main Story	SS_Hush_WayneTower				
@@ -319,9 +312,12 @@ Riddler Trophy (Bleake, Panessa Scan)	Riddler Trophies	PickedUp_CityZ_Pickup_22 
 Riddler Trophy (Bleake, Panessa Questionwall [pathtoscan])	Riddler Trophies	PickedUp_CityZ_Pickup_5 			https://static.gosunoob.com/img/1/2015/06/panessa-studios-puzzle-trophy-outside-1024x576.jpg	
 Riddler Trophy (Bleake Island, North Warehouse)	Riddler Trophies	PickedUp_CityZ_Pickup_33			https://static.gosunoob.com/img/1/2015/06/riddler-trophies-bak-bleake-1024x576.jpg	
 Bomb (Bleake, Chinatown Roundabout)	Bombs	SS_CommandBeacons_CityZ_08_ChD1ab_Ch789.RCommandBeacon_3_destroyed 			https://static.gosunoob.com/img/1/2015/07/campaign-for-disarmamanet-bleake-island-1024x576.jpg	
-Azrael 3 (Roundabout, use map)	Azrael	SS_Azrael_Fight3_Complete				
 Watchtower (Bleake, Chinatown Roundabout)	Watchtower	SS_Watchtowers_CityZ_08_ChX1_Ch789_LOD1.RRadarTower_0_destroyed 			https://static.gosunoob.com/img/1/2015/07/occupy-gotham-bleake-island-1024x576.jpg	
+Azrael 3 (Roundabout, use map)	Azrael	SS_Azrael_Fight3_Complete				
 Penguin 2	Penguin	PenguinCache_C3_Thugs_Done 				
+Riddler Trophy (Bleake, [Cloudburst] Near Clocktower Founders)	Riddler Trophies	PickedUp_CityZ_Pickup_12 			https://static.gosunoob.com/img/1/2015/06/rat-maze-puzzle-trophy-1024x576.jpg	
+Riddler Trophy (Founders, Wooden Wall Near fireman)	Riddler Trophies	PickedUp_CityY_Pickup_20 			https://static.gosunoob.com/img/1/2015/06/founders-island-riddler-trophies-trade-house-1024x576.jpg	
+Riddler Trophy (Founders, ShackNearWaterUnderRail)	Riddler Trophies	PickedUp_CityY_Pickup_24 			https://static.gosunoob.com/img/1/2015/06/arkham-knight-riddler-trophies-founders-island-1024x576.jpg	
 Zsaz Dock Riddle (North Founders)	Riddles	PickedUp_CityY_Riddler_40			https://static.gosunoob.com/img/1/2015/06/founders-island-riddle-solution-1024x576.jpg	
 Riddler Trophy (Founders, North West Wooden Wall)	Riddler Trophies	PickedUp_CityY_Pickup_19			https://static.gosunoob.com/img/1/2015/06/riddler-trophies-construction-site-1024x576.jpg	
 Riddler Trophy (Founders, North West Winch Fly)	Riddler Trophies	PickedUp_CityY_Pickup_4			https://static.gosunoob.com/img/1/2015/06/founders-island-riddler-trophy-construction-site-1024x576.jpg	
@@ -330,12 +326,13 @@ Pyg (Founders, North; Thigh Shoulder Hand)	Pyg	SS_Pyg_Victim6Done			https://stat
 Breakable Shield (Founders, TunnelEntrance LexCorp)	Breakable Objects	PickedUp_CityY_MilitiaShield_7			https://resource.supercheats.com/library/300w/batman-arkham-knight/BO_Founders3B.jpg	
 Breakable Shield (Founders, Underground Wayne Plaza)	Breakable Objects	PickedUp_CityY_MilitiaShield_8			https://resource.supercheats.com/library/300w/batman-arkham-knight/BO_Founders6B.jpg	
 Riddler Trophy (Founders, NorthWest-most area)	Riddler Trophies	PickedUp_CityY_Pickup_26 			https://static.gosunoob.com/img/1/2015/06/founders-island-riddler-trophy-train-yard-1024x576.jpg	
+Freeflow Focus Mk2 Upgrade	Upgrades	Unlocked_FreeflowFocusMk2				
 Firemen (Founders, Northwest-most area)	Firemen	SS_FireCrew_3_Rescued			https://static.gosunoob.com/img/1/2015/07/Founders_Island_The_Line_of_Duty_Batman_Arkham_Knight-1024x576.jpg	
 Bomb (Founders, Urbarail Middle)	Bombs	SS_CommandBeacons_CityY_08_ChD1ab_Ch3456789.RCommandBeacon_1_destroyed     			https://static.gosunoob.com/img/1/2015/07/founders-island-explosive-device-1024x576.jpg	
+Firemen (Founders, MiddleRaisedPlatform)	Firemen	SS_FireCrew_7_Rescued 			https://static.gosunoob.com/img/1/2015/07/Missing_Firefighter_Founders_Island_Batman_Arkham_Knight-1024x576.jpg	
 Checkpoint (Founders, Mideast Top Level)	Checkpoints	Checkpoint_Y_ODestroyed 			https://static.gosunoob.com/img/1/2015/07/Batman_Arkham_Knight_Own_the_Roads_Founders_Island_6-1024x576.jpg	
 Riddler Trophy (Founders, BelowBankWatchtower)	Riddler Trophies	PickedUp_CityY_Pickup_23			https://static.gosunoob.com/img/1/2015/06/riddler-puzzle-trophy-solution-founders-island-1024x576.jpg	
 Watchtower (Founders, Bank Near Stock Exchange)	Watchtower	SS_Watchtowers_CityY_13_ChX1_Ch789_LOD1.RRadarTower_1_destroyed 			https://static.gosunoob.com/img/1/2015/07/goth-corp-watchtower-founders-island-1024x576.jpg	
-Riddler Trophy (Founders, LexCorpBuilding)	Riddler Trophies	PickedUp_CityY_Pickup_12 			https://static.gosunoob.com/img/1/2015/06/synthesizer-puzzle-founders-island-1024x576.jpg	
 APC 6	APC	SS_APC_APC6Complete 				
 Riddler Trophy (Stagg Beta, Voice Synthesizer Front Left)	Riddler Trophies	PickedUp_Stagg_Pickup_20 			https://static.gosunoob.com/img/1/2015/06/riddler-trophy-stagg-airships-location-1024x576.jpg	
 Riddler Trophy (Stagg Beta, Freeze Blast Back Left)	Riddler Trophies	PickedUp_Stagg_Pickup_22 			https://static.gosunoob.com/img/1/2015/06/arkham-knight-monkey-puzzle-airship-1024x576.jpg	
@@ -348,9 +345,10 @@ Riddler Trophy (Stagg Alpha, Crash Glass)	Riddler Trophies	PickedUp_Stagg_Pickup
 Riddler Trophy (Stagg Beta, Fallen Trophy)	Riddler Trophies	PickedUp_Stagg_Pickup_18			https://static.gosunoob.com/img/1/2015/06/stagg-airship-riddler-trophy-dropped-cliff-1024x576.jpg	
 Azrael 4 (LadyGotham)	Azrael	SS_Azrael_Fight4_Complete				
 Watchtower (Miagani, NorthNearLadyOfGotham)	Watchtower	SS_Watchtowers_CityX_05_ChX1_Ch56789_LOD1.RRadarTower_3_destroyed 			https://static.gosunoob.com/img/1/2015/07/miagani-island-occupy-gotham-1024x576.jpg	
-Checkpoint (Miagani, Theater)	Checkpoints	Checkpoint_X_GDestroyed 			https://static.gosunoob.com/img/1/2015/07/Batman_Arkham_Knight_Own_the_Roads_Miagani_Island_7.jpg	
-Watchtower (Miagani, Drone skybridge)	Watchtower	SS_Watchtowers_CityX_10_ChX1_Ch56789_LOD1.RRadarTower_7_destroyed 			https://static.gosunoob.com/img/1/2015/07/turret-puzzle-watchtower-miagani-island-1024x576.jpg	
 Riddler Trophy (Miagani, Gotham Herald Robot Fight)	Riddler Trophies	PickedUp_CityX_Pickup_9 			https://static.gosunoob.com/img/1/2015/06/gotham-herald-riddler-puzzle-trophy-1024x576.jpg	
+Watchtower (Miagani, Drone skybridge)	Watchtower	SS_Watchtowers_CityX_10_ChX1_Ch56789_LOD1.RRadarTower_7_destroyed 			https://static.gosunoob.com/img/1/2015/07/turret-puzzle-watchtower-miagani-island-1024x576.jpg	
+Checkpoint (Miagani, Theater)	Checkpoints	Checkpoint_X_GDestroyed 			https://static.gosunoob.com/img/1/2015/07/Batman_Arkham_Knight_Own_the_Roads_Miagani_Island_7.jpg	
+Tank Energy Storage Protection Upgrade	Upgrades	Unlocked_BmblGeneratorShielding2				
 Breakable Shield (Founders, TunnelEntrance)	Breakable Objects	PickedUp_CityY_MilitiaShield_15 			https://resource.supercheats.com/library/300w/batman-arkham-knight/BO_Founders12B.jpg	
 Riddler Trophy (Founders, OfficeTunnelEntrance)	Riddler Trophies	PickedUp_CityY_Pickup_3 			https://static.gosunoob.com/img/1/2015/06/founders-island-subway-riddler-trophy-1024x576.jpg	
 Riddler Trophy (Founders, Annoying Tank)	Riddler Trophies	PickedUp_CityY_Pickup_5 			https://static.gosunoob.com/img/1/2015/06/riddler-trophy-subway-tank-1024x576.jpg	
@@ -363,13 +361,10 @@ Riddler Trophy (Founders, RightRoomUpAbove)	Riddler Trophies	PickedUp_CityY_Pick
 Riddler Trophy (Founders, NearMiddleRoomOnLeft)	Riddler Trophies	PickedUp_CityY_Pickup_38     			https://static.gosunoob.com/img/1/2015/06/founders-island-subway-tunnel-underground-trophy-1024x576.jpg	
 Breakable Shield (Founders, MiddleRoomOnRight)	Breakable Objects	PickedUp_CityY_MilitiaShield_14 			https://resource.supercheats.com/library/300w/batman-arkham-knight/BO_Founders15B.jpg	
 Riddler Trophy (Founders, LeftRoomOnWood)	Riddler Trophies	PickedUp_CityY_Pickup_39 			https://static.gosunoob.com/img/1/2015/06/subway-tunnel-riddler-trophy-founders-island-1024x576.jpg	
-Riddler Trophy (Bleake, [Cloudburst] Near Clocktower Founders)	Riddler Trophies	PickedUp_CityZ_Pickup_12 			https://static.gosunoob.com/img/1/2015/06/rat-maze-puzzle-trophy-1024x576.jpg	
+Breakable Shield (Founders, UnderWalkwayNearRamp)	Breakable Objects	PickedUp_CityY_MilitiaShield_5 			https://resource.supercheats.com/library/300w/batman-arkham-knight/BO_Founders11B.jpg	
+Breakable Shield (Founders, EastLowerStreetNearChurch)	Breakable Objects	PickedUp_CityY_MilitiaShield_6 			https://resource.supercheats.com/library/300w/batman-arkham-knight/BO_Founders1B.jpg	
 Azrael Done (5 16 28 41) 	Azrael	SS_Azrael_Clocktower_ForensicsStarted				
 Riddler Trophy (Miagani, Midtown Mall Donut Plaza)	Riddler Trophies	PickedUp_CityX_Pickup_6 			https://static.gosunoob.com/img/1/2015/06/riddler-trophy-puzzle-mall-solution-1024x576.jpg	
-Freeflow Focus Mk2 Upgrade	Upgrades	Unlocked_FreeflowFocusMk2				
-Special Combo Batarang upgrade	Upgrades	Unlocked_SpecialComboBatarang				
-Combo Boost Upgrade	Upgrades	Unlocked_SpecialMoveCost				
-Batmobile Dodge Upgrade	Upgrades	Unlocked_BmblDoubleDodge 				
 Riddler Trophy (Miagani, SE BlockedBridge Gears)	Riddler Trophies	PickedUp_CityX_Pickup_3 			https://static.gosunoob.com/img/1/2015/06/riddler-trophy-bridge-puzzle-bak-1024x576.jpg	
 Hush (use map)	Hush	SS_Hush_ShowdownStart 				
 Checkpoint (Miagani, South)	Checkpoints	Checkpoint_X_HDestroyed 			https://static.gosunoob.com/img/1/2015/07/Batman_Arkham_Knight_Own_the_Roads_Final_Militia_Compound-1024x576.jpg	
@@ -377,16 +372,21 @@ Riddler Trophy (Miagani, Ferris Wheel)	Riddler Trophies	PickedUp_CityX_Pickup_12
 Riddler Trophy (Miagani, Past Ferris Wheel)	Riddler Trophies	PickedUp_CityX_Pickup_28 			https://static.gosunoob.com/img/1/2015/06/arkham-knight-riddler-trophy-newton-fairgrounds-1024x576.jpg	
 Riddler Orphanage 4 (Look at linked image)	Riddler Mission	Orphan_09_Complete 			https://static.gosunoob.com/img/1/2015/07/Batman_Arkham_Knight_Advanced_Deathtraps_Riddlers_Revenge-1024x576.jpg	
 Riddler Bomb (Miagani, Near Orphanage)	Riddler Bomb	PickedUp_CityX_Bomb_16 			https://static.gosunoob.com/img/1/2015/07/Miagani_Island_Riddler_Victim_Batman_Arkham_Knight_1-1024x576.jpg	
+Pyg (Miagani, NearFoundersIsland; Torso Eye Arm)	Pyg	SS_Pyg_Victim4Done 			https://static.gosunoob.com/img/1/2015/07/Batman_Arkham_Knight_Mutilated_Body_Miagani_Island_1-1024x576.jpg	
+Watchtower (Miagani, Near Bridge By Orphanage)	Watchtower	SS_Watchtowers_CityX_28_ChX1_Ch56789_LOD1.RRadarTower_12_destroyed 			https://static.gosunoob.com/img/1/2015/07/miagani-island-militia-watchtower-1024x576.jpg	
 Riddler Trophy (Miagani, Under UpperFoundersBridge)	Riddler Trophies	PickedUp_CityX_Pickup_8 			https://static.gosunoob.com/img/1/2015/06/arkham-knight-miagani-island-puzzle-trophy-solution-1024x576.jpg	
 Riddler Trophy (Miagani, Top Of Hospital Race)	Riddler Trophies	PickedUp_CityX_Pickup_17 			https://static.gosunoob.com/img/1/2015/06/miagani-island-time-trial-hospital-1024x576.jpg	
+Watchtower (Miagani, Gotham Bank)	Watchtower	SS_Watchtowers_CityX_11_ChX1_Ch789_LOD1.RRadarTower_8_destroyed 			https://static.gosunoob.com/img/1/2015/07/bank-of-gotham-militia-watchtower-miagani-island-1024x576.jpg	
 Riddler Race 3 (use map 3 1)	Riddler Mission	Orphan_C7_RaceComplete 				
 Checkpoint (Miagani, SouthOfMercyBridge)	Checkpoints	Checkpoint_X_EDestroyed 			https://static.gosunoob.com/img/1/2015/07/Batman_Arkham_Knight_Own_the_Roads_Miagani_Island_6-1024x576.jpg	
 Riddler Trophy (Miagani, Mercy Bridge)	Riddler Trophies	PickedUp_CityX_Pickup_13 			https://static.gosunoob.com/img/1/2015/06/riddler-trophy-miagani-island-solution-1024x576.jpg	
 Watchtower (Miagani, NextToBridgeAcrossFromGCPD)	Watchtower	SS_Watchtowers_CityX_06_ChX1_Ch789_LOD1.RRadarTower_1_destroyed 			https://static.gosunoob.com/img/1/2015/07/miagani-island-militia-watchtower-side-mission-1024x576.jpg	
 Checkpoint (Miagani, NextToBridgeAcrossFromGCPD)	Checkpoints	Checkpoint_X_DDestroyed 			https://static.gosunoob.com/img/1/2015/07/Batman_Arkham_Knight_Own_the_Roads_Miagani_Island_5-1024x576.jpg	
 Bomb (Miagani, NextToParkingGarage)	Bombs	SS_CommandBeacons_CityX_06_ChD1ab_Ch789.RCommandBeacon_1_destroyed 			https://static.gosunoob.com/img/1/2015/07/miagani-island-landmine-defuse-1024x576.jpg	
-Watchtower (Miagani, Gotham Bank)	Watchtower	SS_Watchtowers_CityX_11_ChX1_Ch789_LOD1.RRadarTower_8_destroyed 			https://static.gosunoob.com/img/1/2015/07/bank-of-gotham-militia-watchtower-miagani-island-1024x576.jpg	
 Two Face Bank 3 (Miagani)	Two Face	Bank03_Empty 				
+Batmobile Dodge Upgrade	Upgrades	Unlocked_BmblDoubleDodge 				
+Ram Charge Upgrade	Upgrades	Unlocked_BmblRamCharge				
+Sabotoge Drone Upgrade	Upgrades	Unlocked_DisruptorSabDrone				
 APC 7	APC	SS_APC_APC7Complete 				
 Manbat Done	ManBat	SS_ManBat_Cure_FullDose2 				
 Speak to GCPD Dude	Main Story	Ch8_Track_Gordon_Objective_Added 				
@@ -421,17 +421,17 @@ Breakable (ArkhamHQ, L4 Elevator After Sentry)	Breakable Objects	PickedUp_HideOu
 Riddler Trophy (ArkhamHQ, L4 Right Of Generator)	Riddler Trophies	PickedUp_HideOut_Pickup_4 			https://static.gosunoob.com/img/1/2015/07/locked-elevator-puzzle-riddler-trophy-arkham-knight-hq-1024x576.jpg	
 Riddler Trophy (ArkhamHQ, Tunnel After Excavator)	Riddler Trophies	PickedUp_HideOut_Pickup_13 			https://static.gosunoob.com/img/1/2015/07/arkham-knight-boss-fight-riddler-trophy-1024x576.jpg	
 Clocktower Riddle	Riddles	PickedUp_CityZ_Riddler_28 				
+Checkpoint (Bleake, SE Chinatown)	Checkpoints	Checkpoint_Z_CDestroyed 			https://static.gosunoob.com/img/1/2015/07/Batman_Arkham_Knight_Own_the_Roads_Bleake_Island_4-1024x576.jpg	
 Riddler Trophy (Miagani Island, Lady of Gotham)	Riddler Trophies	PickedUp_CityX_Pickup_23 			https://static.gosunoob.com/img/1/2015/06/riddler-trophy-lady-liberty-1024x576.jpg	
 Deacon	Deacon	SS_Deacon_COMPLETE 				
 Penguin 3	Penguin	PenguinCache_C4_Thugs_Done 				
+Wonder Tower Riddle (with penguin truck)	Riddles	PickedUp_CityX_Riddler_2 			https://static.gosunoob.com/img/1/2015/06/miagani-riddle-wayne-tower-1024x576.jpg	
+Checkpoint (Bleake, Chinatown 3 turrets)	Checkpoints	Checkpoint_Z_BDestroyed 			https://static.gosunoob.com/img/1/2015/07/Batman_Arkham_Knight_Own_the_Roads_Bleake_Island_1-1024x576.jpg	
 Riddler Trophy (Bleake, Panessa Studios Tunnel [before penguin])	Riddler Trophies	PickedUp_CityZ_Pickup_2			https://static.gosunoob.com/img/1/2015/06/panessa-studios-underground-puzzle-trophy-1024x576.jpg	
 Riddler Trophy (Bleake, Penguin 3 Tunnel)	Riddler Trophies	PickedUp_CityZ_Pickup_39 			https://static.gosunoob.com/img/1/2015/06/penguin-cache-riddler-trophy-1024x576.jpg	
 Riddler Trophy (Bleake, Robot Near Ace Bridge)	Riddler Trophies	PickedUp_CityZ_Pickup_15 			https://static.gosunoob.com/img/1/2015/06/bleake-island-puzzle-trophy-solution-1024x576.jpg	
 Riddler Bomb (Bleake Island, North Urbarail Hotel)	Riddler Bomb	PickedUp_CityZ_Bomb_17			https://static.gosunoob.com/img/1/2015/06/Bleake_Island_Riddler_Victim_Batman_Arkham_Knight_1-1024x576.jpg	
-Checkpoint (Bleake, Chinatown 3 turrets)	Checkpoints	Checkpoint_Z_BDestroyed 			https://static.gosunoob.com/img/1/2015/07/Batman_Arkham_Knight_Own_the_Roads_Bleake_Island_1-1024x576.jpg	
-Checkpoint (Bleake, SE Chinatown)	Checkpoints	Checkpoint_Z_CDestroyed 			https://static.gosunoob.com/img/1/2015/07/Batman_Arkham_Knight_Own_the_Roads_Bleake_Island_4-1024x576.jpg	
 Checkpoint (Bleake, NextToFoundersBridge)	Checkpoints	Checkpoint_Z_ADestroyed			https://static.gosunoob.com/img/1/2015/07/Batman_Arkham_Knight_Own_the_Roads_Bleake_Island_2-1024x576.jpg	
-Sabotoge Drone Upgrade	Upgrades	Unlocked_DisruptorSabDrone				
 Checkpoint (Bleake, Next to previous checkpoint)	Checkpoints	Checkpoint_Z_UDestroyed			https://static.gosunoob.com/img/1/2015/07/Batman_Arkham_Knight_Own_the_Roads_Bleake_Island_3-1024x576.jpg	
 Checkpoint (Founders, North)	Checkpoints	Checkpoint_Y_TDestroyed 			https://static.gosunoob.com/img/1/2015/07/Batman_Arkham_Knight_Own_the_Roads_Founders_Island_3-1024x576.jpg	
 Riddler Trophy (Founders, In Checkpoint)	Riddler Trophies	PickedUp_CityY_Pickup_10			https://static.gosunoob.com/img/1/2015/06/arkham-knight-riddler-puzzle-drivethrough-1024x576.jpg	
@@ -442,7 +442,6 @@ GCPD Assault	Main Story	Ch9c_Assault_on_GCPD_Complete
 Riddler Trophy (Panessa, Left After Entrance Robots)	Riddler Trophies	PickedUp_Film_Pickup_28			https://static.gosunoob.com/img/1/2015/06/robot-takedown-riddler-trophy-panessa-studios-1024x576.jpg	
 Riddler Trophy (Panessa, Middle Room BAC)	Riddler Trophies	PickedUp_Film_Pickup_33 			https://static.gosunoob.com/img/1/2015/06/panessa-studios-poseidon-statue-riddler-trophy-1024x576.jpg	
 Riddler Trophy (Panessa, Stage C Corridor Robot Freeze Grenade)	Riddler Trophies	PickedUp_Film_Pickup_31 			https://static.gosunoob.com/img/1/2015/06/arkham-knight-studios-riddler-trophy-voice-puzzle-1024x576.jpg	
-Breakable (Panessa, Before Stage C Door)	Breakable Objects	PickedUp_Film_JackInTheBox_13 			https://resource.supercheats.com/library/300w/batman-arkham-knight/BO_Panessa7B.jpg	
 Breakable (Panessa, Stage C vent)	Breakable Objects	PickedUp_Film_JackInTheBox_10			https://resource.supercheats.com/library/300w/batman-arkham-knight/BO_Panessa9B.jpg	
 Riddler Trophy (Panessa, Stage C Remote Batarang)	Riddler Trophies	PickedUp_Film_Pickup_39			https://static.gosunoob.com/img/1/2015/06/stage-c-riddler-puzzle-trophy-vent-1024x576.jpg	
 Riddler Trophy (Panessa, Slot Machine)	Riddler Trophies	PickedUp_Film_Pickup_36			https://static.gosunoob.com/img/1/2015/06/slot-puzzle-trophy-panessa-studios-1024x576.jpg	
@@ -486,6 +485,7 @@ Riddler Trophy (Founders, Port Adams Entrance Office)	Riddler Trophies	PickedUp_
 Riddler Trophy (Founders, Port Adams Middle)	Riddler Trophies	PickedUp_CityY_Pickup_11 			https://static.gosunoob.com/img/1/2015/06/arkham-knight-shipyard-puzzle-trophy-1024x576.jpg	
 Firemen (Founders, Port Adams)	Firemen	SS_FireCrew_6_Rescued 			https://static.gosunoob.com/img/1/2015/07/Batman_Arkham_Knight_The_Line_of_Duty_Founders_Island-1024x576.jpg	
 Riddler Trophy (Founders, Outside East Port Adams)	Riddler Trophies	PickedUp_CityY_Pickup_34 			https://static.gosunoob.com/img/1/2015/07/founders-island-dock-platform-riddler-trophy-1024x576.jpg	
+Watchtower (Founders, NearPortAdams)	Watchtower	SS_Watchtowers_CityY_17_ChX1_Ch3456789_LOD1.RRadarTower_19_destroyed 			https://static.gosunoob.com/img/1/2015/07/militia-watchtower-location-founders-island-1024x576.jpg	
 Fire Chief	Firemen	SS_Firechief_InBatmobile_Dialogue 				
 Deathstroke Riddle (In GCPD)	Riddles	PickedUp_CityZ_Riddler_12 				
 APC 8	APC	SS_APC_APC8Complete 				
@@ -495,3 +495,4 @@ APC 9	APC	SS_APC_APC9Complete
 Riddler Riddle	Riddles	PickedUp_CityX_Riddler_33 				
 Riddler Orphanage 5+6+7	Riddler Mission	Lockup_B1_Riddler_Lockedup 				
 Scarecrow Done	Main Story	AK_Main_Game_Complete				
+Knightfall	Main Story					

--- a/ArkhamDisplay/Routes/Origins.tsv
+++ b/ArkhamDisplay/Routes/Origins.tsv
@@ -67,7 +67,6 @@ Anarky Tag (Park Row, Ace Building)	Anarky Tags	PickedUp_AnarkyScan_Anarky_27
 Anarky Tag (Park Row, Near Monarch Theater)	Anarky Tags	PickedUp_AnarkyScan_Anarky_21				
 Datapack (Park Row, Slide Under Light Bulb Sign)	Datapacks	PickedUp_ParkRow_Pickup_11				
 Datapack (Park Row, Gel Wall Roof Behind Monarch Theater)	Datapacks	PickedUp_ParkRow_Pickup_9				
-Relay (Park Row, Alley Across Gotham Hardware [behind monarch])	Relays (Park Row)	PickedUp_ParkRow_Camera_8				
 Datapack (Park Row, Gotham Hardware Building by Vent)	Datapacks	PickedUp_ParkRow_Pickup_10				
 Relay (Park Row, Building near Bridge Across Church)	Relays (Park Row)	PickedUp_ParkRow_Camera_4				
 Relay (Park Row, Finnigans Under Beer Sign)	Relays (Park Row)	PickedUp_ParkRow_Camera_3				
@@ -425,6 +424,7 @@ Burnley Hit & Run (Burnley, Near GCPD)	Crime Scene	CrimeScene03_C3PaintChip
 Solve Burnley Hit & Run (Burnley, Across GCR)	Crime Scene	CrimeScene03_CaseFileClosed				
 Amusement Mile Mauling (Amusement, Gotham Casino)	Crime Scene	CrimeScene02_CaseFileScanningComplete				
 Solve Amusement Mile Mauling (Park Row, Auto Repair/Live Nudes)	Crime Scene	CrimeScene02_CaseFileClosed				
+Relay (Park Row, Alley Across Gotham Hardware [behind monarch])	Relays (Park Row)	PickedUp_ParkRow_Camera_8				
 Crime Alley Shootings (Park Row, Between Monarch Theater and Church)	Crime Scene	CrimeScene06_CaseFileScanningComplete				
 Solve Crime Alley Shootings (Industrial, Behind Steel Mill)	Crime Scene	CrimeScene06_CaseFileClosed				
 Blackgate Prisoner (Industrial, Between Steel Mill and Bridge)	Blackgate Prisoners	MW_BGP_Prisoner_06_Captured				


### PR DESCRIPTION
First Ending: 
* Remove two face banks
* Remove afterburner recharge upgrades. 
* Move up reload speed and turret shot upgrades to be with cobra lure

Full Ending: 
* Sionis Crane shield to be done during the first bomb
* Move GCPD and Kord shields to be done during the lowering of the bridge
* Move Cash riddle to be after Stagg/before taking Ivy to the gardens
* Move ACE trophy and 2 shields to be after visiting Manbat lab
* Do league of assassin's riddle right after you bring the tank onto Miagani
* Reorder 2nd and 3rd miagani shields (minor)
* Move newton fairgrounds shield to be during the botanical gardens bomb
* Move church trophy to be right after picking up the first tank upgrade
* Reorder the shields near Ferry terminal
* Do bridge firefighter before doing APC 1
* Move grapnel boost mk3 to be during the elevator ride for Riddler Puzzle 1
* Add Grapnel Takedown upgrade
* Move wood wall firefighter trophy to be done during Penguin 2 truck
* Minor change, moving tank upgrades to be after GCPD/Ivy/Cobras row
* Reroute orphanage pyg and watchtower to after Riddler Orphanage 4
* Move Energy Storage Protection upgrade to right before going to the subway tunnels
* Move wonder tower riddle to be with Penguin 3 truck
* Get grapnel boost mk4 upgrade with the fear takedown upgrades.
* Move robin riddle to later, when we help him after harley takes over.
* Remove two face banks
* Move founders island shack trophy to be done during Penguin 2 truck
* Reroute relay drone to be right after the Amertek watchtower. Move brige/pier trophy, water checkpoint, and nearby watchtower to after missile launcher, before bank 2 bomb.
* Move port adams watchtower to right before fire chief
* Move lexcorp robot trophy to be before radar 2
* Reroute urbarail firefighter to be right after urbarail bomb
* Reroute monuments trophy, gothcorp riddle, firefly watchtower, and cobblepot riddle to be after bank 2 bomb.
* Add combo boost to the list of upgrades you get right after panessa roof predator.
* Reroute panessa collectibles based on the panessa skips. Move one breakable from the end to earlier.
* Move chinatown watchtower to before Azrael 3
* Move trophy next to clocktower to be done with penguin 3 truck
* Move gotham herald robot trophy to before skybridge watchtower
* Move two founder shields to be done while waiting for divinity church tanks
* Move gotham bank watchtower to be before Riddler Race 3
* Get Ram Charge Upgrade, Batmobile Dodge upgrade, and sabotoge drone upgrade after two face 3
* Do clocktower checkpoint right after clocktower predator, before Deacon Blackfire
* Do 3-turret checkpoint after tracking Penguin 3 truck

Origins:
* Move crime alley relay to be during the crime alley crime scene.