### PR TITLE
Fix DataHandler issue in Origins

### DIFF
--- a/ArkhamDisplay/OriginsSave.cs
+++ b/ArkhamDisplay/OriginsSave.cs
@@ -6,8 +6,9 @@ namespace ArkhamDisplay{
 
 		public override bool HasKey(Entry entry, int requiredMatches){
 			if("Data Handler".Equals(entry.type)){
-				return !HasKey(entry.id, requiredMatches) && !HasKey(entry.alternateID, requiredMatches);
-			}else if("DarkKnightFinish".Equals(entry.metadata)){
+				return HasKey("SS_Enigma_EnigmaHQ_Visited", requiredMatches) && !HasKey(entry.id, requiredMatches) && !HasKey(entry.alternateID, requiredMatches);
+			}
+			else if("DarkKnightFinish".Equals(entry.metadata)){
 				return HasKeyCustomRegex(@"\b" + entry.id + @"............" + Convert.ToChar(Convert.ToByte("0x1", 16)), requiredMatches);
 			}
 


### PR DESCRIPTION
Previously, data handlers would show up as completed at the start, because Origins is weird and removes them as you do them. However, data handlers are only available after visiting Enigma's HQ. Adding a check to see if we've visited Enigma's HQ seems to fix the issue.