### PR TITLE
Always on top feature

### DIFF
--- a/ArkhamDisplay/BaseWindow.cs
+++ b/ArkhamDisplay/BaseWindow.cs
@@ -409,6 +409,13 @@ namespace ArkhamDisplay{
 			}else{
 				riddleCounter.Visibility = Visibility.Collapsed;
 			}
+
+			if(Data.AlwaysOnTop){
+				this.Topmost = true;
+      }
+      else{
+				this.Topmost = false;
+      }
 		}
 
 		protected virtual void UpdatePreferences(object sender = null, RoutedEventArgs e = null){

--- a/ArkhamDisplay/Data.cs
+++ b/ArkhamDisplay/Data.cs
@@ -11,6 +11,11 @@ namespace ArkhamDisplay{
 		Dark = 2
 	}
 
+	public enum AlwaysOnTop{
+		Activated = 0,
+		Deactivated = 1
+	}
+
 	public enum Game{
 		None = -1,
 		Asylum = 0,
@@ -27,6 +32,7 @@ namespace ArkhamDisplay{
 
 	public class DataBlock{
 		public volatile Theme savedTheme = Theme.Default;
+		public volatile bool alwaysOnTop = false;
 		public volatile Game selectedGame = Game.None;
 		public volatile string[] saveLocations = { "", "", "", "" };
 		public volatile int[] saveIDs = { 0, 0, 0, 0 };
@@ -67,6 +73,7 @@ namespace ArkhamDisplay{
 
 		public static string VersionStr { get { return "1.8"; } }
 
+		public static bool AlwaysOnTop { get { return data.alwaysOnTop; } set { data.alwaysOnTop = value; } }
 		public static string RoutePath { get { return "\\Routes\\"; } }
 		public static Game SelectedGame { get { return data.selectedGame; } set { data.selectedGame = value; } }
 		public static string[] SaveLocations { get { return data.saveLocations; } }
@@ -76,7 +83,6 @@ namespace ArkhamDisplay{
 		public static double MainRowHeight { get { return (double)data.mainRowHeight; } set { data.mainRowHeight = (float)value; } }
 		public static double SecondaryRowHeight { get { return (double)data.secondaryRowHeight; } set { data.secondaryRowHeight = (float)value; } }
 		public static bool StatsWindowOpen { get { return data.statsWindowOpen; } set { data.statsWindowOpen = value; } }
-
 		public static bool ShowPercent { get { return data.showPercent; } set { data.showPercent = value; } }
 		public static bool ShowRiddleCount { get { return data.showRiddleCount; } set { data.showRiddleCount = value; } }
 		public static int RefreshRate { get { return data.refreshRateInMS; } set { data.refreshRateInMS = value; } }

--- a/ArkhamDisplay/Data.cs
+++ b/ArkhamDisplay/Data.cs
@@ -11,11 +11,6 @@ namespace ArkhamDisplay{
 		Dark = 2
 	}
 
-	public enum AlwaysOnTop{
-		Activated = 0,
-		Deactivated = 1
-	}
-
 	public enum Game{
 		None = -1,
 		Asylum = 0,

--- a/ArkhamDisplay/PreferencesWindow.xaml
+++ b/ArkhamDisplay/PreferencesWindow.xaml
@@ -5,11 +5,12 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 		mc:Ignorable="d"
         Title="Preferences" Height="280" Width="300"
-		ResizeMode="NoResize">
+		ResizeMode="NoResize"
+    Topmost="True">
 	<Grid>
 		<Grid.RowDefinitions>
 			<RowDefinition Height="10*"/>
-			<RowDefinition Height="32*"/>
+			<RowDefinition Height="38*"/>
 			<RowDefinition Height="25*"/>
 			<RowDefinition Height="15*"/>
 		</Grid.RowDefinitions>
@@ -23,6 +24,7 @@
 		<CheckBox Name="ShowRiddlesCheckbox"	Content="Show Riddle Count"	Grid.Row="1" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="10,28,0,0" IsChecked="True"/>
 		<CheckBox Name="ShowWarningsCheckbox"	Content="Highlight Missed Entries"	Grid.Row="1" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="10,48,0,0" IsChecked="True"/>
 		<CheckBox Name="DarkThemeCheckbox"		Content="Dark Mode"			Grid.Row="1" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="10,68,0,0" IsChecked="True"/>
+    <CheckBox Name="AlwaysOnTopCheckbox"		Content="Always Keep Main Window On Top"			Grid.Row="1" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="10,88,0,0" IsChecked="False"/>
 
 		<RadioButton Name="ShowAllButton"	Content="Show all entries"				Grid.Row="2" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="10,10,0,0" IsChecked="True"/>
 		<RadioButton Name="SortDoneButton"	Content="Sort completed entries to top"	Grid.Row="2" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="10,30,0,0" IsChecked="False"/>

--- a/ArkhamDisplay/PreferencesWindow.xaml.cs
+++ b/ArkhamDisplay/PreferencesWindow.xaml.cs
@@ -22,6 +22,7 @@ namespace ArkhamDisplay{
 			ShowProgressCheckbox.IsChecked = Data.ShowPercent;
 			ShowRiddlesCheckbox.IsChecked = Data.ShowRiddleCount;
 			ShowWarningsCheckbox.IsChecked = Data.WarningsForMissedEntries;
+			AlwaysOnTopCheckbox.IsChecked = Data.AlwaysOnTop;
 
 			if(Data.UseTheme() == Theme.Dark){
 				DarkThemeCheckbox.IsChecked = true;
@@ -54,6 +55,7 @@ namespace ArkhamDisplay{
 			Data.ShowPercent = ShowProgressCheckbox.IsChecked ?? false;
 			Data.ShowRiddleCount = ShowRiddlesCheckbox.IsChecked ?? false;
 			Data.WarningsForMissedEntries = ShowWarningsCheckbox.IsChecked ?? false;
+			Data.AlwaysOnTop = AlwaysOnTopCheckbox.IsChecked ?? false;
 
 			if(DarkThemeCheckbox.IsChecked == true){
 				Data.SetTheme(Theme.Dark);


### PR DESCRIPTION
The changes are fairly minimal.

I added the option to the preferences, had to do some resizing for the window to make it fit.
The always on top feature only affects the main windows, as requested.
I change the behavior in the existing `UpdateUI`-function inside `BaseWindow.cs`. 

I made it so that the Settings-/Preferences-window is always on top. Figured it's easiest for now since you typically don't leave it open anyways.

